### PR TITLE
generate source maps for distribution

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
         children: true,
     },
     context: __dirname,
+    devtool: 'source-map',
     entry: {
         openplayer: ['./src/js/player.ts', './src/css/player.css'],
     },


### PR DESCRIPTION
The be able to pin down problems in production, it's invaluable to have source maps available. This sets `devtool: 'source-map'`, the recommended choice for production builds with high quality SourceMaps according to the docs: https://webpack.js.org/configuration/devtool/