### PR TITLE
Fix ad request muted state

### DIFF
--- a/src/js/media/ads.ts
+++ b/src/js/media/ads.ts
@@ -943,7 +943,7 @@ class Ads {
         this.#request.nonLinearAdSlotWidth = width;
         this.#request.nonLinearAdSlotHeight = height / 3;
         this.#request.setAdWillAutoPlay(this.#autostart);
-        this.#request.setAdWillPlayMuted(this.#autostartMuted);
+        this.#request.setAdWillPlayMuted(this.#autostartMuted || this.#muted);
         this.#loader.requestAds(this.#request);
     }
 


### PR DESCRIPTION
The ad request currently ignores if the player is in muted state, accounting only if the player can autostart with audio.
This will cause policy violations, because the ad request does not reflect the real audibility of the ad placement.

This fix addresses the problem, by taking into account the actual muted state of the player.