### PR TITLE
fix(ads): normalize ads.error payload to include message string and error object

### DIFF
--- a/packages/ads/__tests__/ads.sourceMode.test.ts
+++ b/packages/ads/__tests__/ads.sourceMode.test.ts
@@ -306,6 +306,58 @@ describe('AdsPlugin – adSourcesMode: waterfall', () => {
     expect(adVideo).not.toBeNull();
   });
 
+  test('waterfall: ads.error payload has message string and error object', async () => {
+    const networkErr = new Error('network error');
+    vastGetMock.mockRejectedValueOnce(networkErr).mockResolvedValueOnce(linearParsed());
+
+    const { ctx, bus } = makeCtx();
+    const errorPayloads: unknown[] = [];
+    bus.on('ads:error', (payload: unknown) => errorPayloads.push(payload));
+
+    const plugin = new AdsPlugin({
+      adSourcesMode: 'waterfall',
+      sources: [
+        { type: 'VAST', src: 'https://failing.example.com/vast' },
+        { type: 'VAST', src: 'https://working.example.com/vast' },
+      ],
+    });
+    plugin.setup(ctx);
+
+    (ctx.events as any).emit('cmd:play');
+    await waitForAdVideo();
+
+    expect(errorPayloads).toHaveLength(1);
+    const payload = errorPayloads[0] as { message: string; error: unknown };
+    expect(typeof payload.message).toBe('string');
+    expect(payload.message).toBe('network error');
+    expect(payload.error).toBe(networkErr);
+  });
+
+  test('waterfall: ads.error payload has message when non-Error is thrown', async () => {
+    vastGetMock.mockRejectedValueOnce('plain string error').mockResolvedValueOnce(linearParsed());
+
+    const { ctx, bus } = makeCtx();
+    const errorPayloads: unknown[] = [];
+    bus.on('ads:error', (payload: unknown) => errorPayloads.push(payload));
+
+    const plugin = new AdsPlugin({
+      adSourcesMode: 'waterfall',
+      sources: [
+        { type: 'VAST', src: 'https://failing.example.com/vast' },
+        { type: 'VAST', src: 'https://working.example.com/vast' },
+      ],
+    });
+    plugin.setup(ctx);
+
+    (ctx.events as any).emit('cmd:play');
+    await waitForAdVideo();
+
+    expect(errorPayloads).toHaveLength(1);
+    const payload = errorPayloads[0] as { message: string; error: unknown };
+    expect(payload.message).toBe('plain string error');
+    expect(payload.error).toBe('plain string error');
+  });
+
   test('waterfall with single source uses standard single-source path', async () => {
     vastGetMock.mockResolvedValue(linearParsed());
 
@@ -450,5 +502,74 @@ describe('AdsPlugin – adSourcesMode: playlist', () => {
     const breaks = (plugin as any).resolvedBreaks;
     const vastBreaks = breaks.filter((b: any) => b.source?.type !== 'VMAP');
     expect(vastBreaks).toHaveLength(2);
+  });
+
+  test('playlist: plays first source ad on first cmd:play', async () => {
+    vastGetMock.mockResolvedValue(linearParsed());
+
+    const { ctx } = makeCtx();
+    const plugin = new AdsPlugin({
+      adSourcesMode: 'playlist',
+      sources: [
+        { type: 'VAST', src: 'https://ad1.example.com/vast' },
+        { type: 'VAST', src: 'https://ad2.example.com/vast' },
+      ],
+    });
+    plugin.setup(ctx);
+
+    (ctx.events as any).emit('cmd:play');
+    const adVideo = await waitForAdVideo();
+
+    expect(vastGetMock).toHaveBeenCalledWith('https://ad1.example.com/vast');
+    expect(adVideo).not.toBeNull();
+  });
+
+  test('playlist: ads.error payload has message string and error object', async () => {
+    const networkErr = new Error('fetch failed');
+    vastGetMock.mockRejectedValueOnce(networkErr).mockResolvedValueOnce(linearParsed());
+
+    const { ctx, bus } = makeCtx();
+    const errorPayloads: unknown[] = [];
+    bus.on('ads:error', (payload: unknown) => errorPayloads.push(payload));
+
+    const plugin = new AdsPlugin({
+      adSourcesMode: 'playlist',
+      sources: [
+        { type: 'VAST', src: 'https://failing.example.com/vast' },
+        { type: 'VAST', src: 'https://working.example.com/vast' },
+      ],
+    });
+    plugin.setup(ctx);
+
+    (ctx.events as any).emit('cmd:play');
+    // Flush enough microtasks for the first break to fail and error to emit
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    expect(errorPayloads).toHaveLength(1);
+    const payload = errorPayloads[0] as { message: string; error: unknown };
+    expect(typeof payload.message).toBe('string');
+    expect(payload.message).toBe('fetch failed');
+    expect(payload.error).toBe(networkErr);
+  });
+
+  test('playlist: all sources fetched even if one fails', async () => {
+    vastGetMock.mockRejectedValueOnce(new Error('source 1 failed')).mockResolvedValueOnce(linearParsed());
+
+    const { ctx } = makeCtx();
+    const plugin = new AdsPlugin({
+      adSourcesMode: 'playlist',
+      sources: [
+        { type: 'VAST', src: 'https://ad1.example.com/vast' },
+        { type: 'VAST', src: 'https://ad2.example.com/vast' },
+      ],
+    });
+    plugin.setup(ctx);
+
+    (ctx.events as any).emit('cmd:play');
+    // Allow first break to fail and second to be attempted
+    for (let i = 0; i < 15; i++) await Promise.resolve();
+
+    expect(vastGetMock).toHaveBeenCalledWith('https://ad1.example.com/vast');
+    expect(vastGetMock).toHaveBeenCalledWith('https://ad2.example.com/vast');
   });
 });

--- a/packages/ads/src/strategies/csai.ts
+++ b/packages/ads/src/strategies/csai.ts
@@ -171,7 +171,10 @@ export class CsaiAdStrategy implements AdSessionStrategy {
     kind: 'preroll' | 'midroll' | 'postroll' | 'auto',
     opts?: { suppressResume?: boolean }
   ) => Promise<void>;
-  _dispatchStartBreakGroup!: (breaks: AdsBreakConfig[], kind: 'preroll' | 'midroll' | 'postroll' | 'auto') => Promise<void>;
+  _dispatchStartBreakGroup!: (
+    breaks: AdsBreakConfig[],
+    kind: 'preroll' | 'midroll' | 'postroll' | 'auto'
+  ) => Promise<void>;
   _dispatchPlayBreakFromVast!: (
     input: VastInput,
     meta: { kind: 'preroll' | 'midroll' | 'postroll' | 'auto' | 'manual'; id: string; sourceType?: AdsSourceType },
@@ -179,7 +182,11 @@ export class CsaiAdStrategy implements AdSessionStrategy {
   ) => Promise<boolean>;
   _dispatchGetVastXmlText!: (input: VastInput) => Promise<string>;
   _dispatchBuildParsedForNonLinear!: (xmlText: string) => XMLDocument | null;
-  _dispatchMountAdVideo!: (contentMedia: HTMLMediaElement, mediaFile: { fileURL: string; raw: any }, creative?: any) => void;
+  _dispatchMountAdVideo!: (
+    contentMedia: HTMLMediaElement,
+    mediaFile: { fileURL: string; raw: any },
+    creative?: any
+  ) => void;
   _dispatchStartAdPlayback!: () => void;
 
   private simidSession?: SimidSession;
@@ -511,7 +518,11 @@ export class CsaiAdStrategy implements AdSessionStrategy {
     this.startingBreak = true;
     this.bus.emit('ads:break:start', { id, kind, at: b.at });
     try {
-      await this._dispatchPlayBreakFromVast(input, { kind, id, sourceType }, { suppressResumeOnSuccess: opts?.suppressResume });
+      await this._dispatchPlayBreakFromVast(
+        input,
+        { kind, id, sourceType },
+        { suppressResumeOnSuccess: opts?.suppressResume }
+      );
     } finally {
       this.startingBreak = false;
       this.bus.emit('ads:break:end', { id, kind, at: b.at });
@@ -782,8 +793,9 @@ export class CsaiAdStrategy implements AdSessionStrategy {
       });
       return true;
     } catch (err) {
-      this.bus.emit('ads:error', err);
-      this.ctx.events.emit('ads.error', { err });
+      const message = err instanceof Error ? err.message : String(err);
+      this.bus.emit('ads:error', { message, error: err });
+      this.ctx.events.emit('ads.error', { message, error: err });
       this.finish({
         resume: meta.kind !== 'postroll' && (this.userPlayIntent || this.resumeAfter),
         suppressResume: opts?.suppressResumeOnError,


### PR DESCRIPTION
## Summary
- `playBreakFromVast()` was emitting `{ err }` on both the internal `PluginBus`
  and the player `EventBus` when a VAST source failed. Because `Error` properties
  are non-enumerable, this serialized as `{}` in the console and made the payload
  useless to consumers.
- Both buses now emit `{ message, error }` — `message` is always a readable
  string (`err.message` for `Error` instances, `String(err)` otherwise), and
  `error` holds the raw thrown value for consumers that need it.
## Tests added
- `waterfall: ads.error payload has message string and error object`
- `waterfall: ads.error payload has message when non-Error is thrown`
- `playlist: ads.error payload has message string and error object`
- `playlist: plays first source ad on first cmd:play`
- `playlist: all sources fetched even if one fails`
## Reviewer notes
The `vmap_parse_failed` error path at csai.ts:201-202 already emitted a
structured `{ reason, error }` object and is unchanged — only the catch block
in `playBreakFromVast` was affected.