### PR TITLE
feat(core,player): sourceFallback on by default, isLive from Infinity duration, showLiveCurrentTime config

### DIFF
--- a/e2e/helpers/player.ts
+++ b/e2e/helpers/player.ts
@@ -19,6 +19,7 @@ export const sel = {
   settingsItems: '.op-controls__menu-item',
   settingsBack: '.op-submenu__back',
   centerOverlay: '.op-player__play',
+  currentTime: 'time.op-controls__current',
 } as const;
 
 /**

--- a/e2e/live.spec.ts
+++ b/e2e/live.spec.ts
@@ -7,6 +7,23 @@ test.describe('Live — HLS live stream', () => {
     await loadExample(page, '/examples/live.html');
   });
 
+  // ── isLive auto-detection ──────────────────────────────────────────────────
+
+  test('core.isLive is true after live stream starts playing', async ({ page }) => {
+    await clickPlay(page);
+    await waitForPlayback(page, 1);
+
+    const isLive = await page.evaluate(() => (window as any).__core?.isLive);
+    expect(isLive).toBe(true);
+  });
+
+  test('current time control is hidden by default during live playback', async ({ page }) => {
+    await clickPlay(page);
+    await waitForPlayback(page, 1);
+
+    await expect(page.locator(sel.currentTime)).toHaveAttribute('aria-hidden', 'true');
+  });
+
   // ── Render ─────────────────────────────────────────────────────────────────
 
   test('renders player wrapper and controls', async ({ page }) => {
@@ -133,5 +150,26 @@ test.describe('Live — HLS live stream', () => {
     // Turn OFF again — confirm the toggle is reversible.
     await captionsBtn.click();
     await expect(captionsBtn).toHaveAttribute('aria-pressed', 'false', { timeout: 3_000 });
+  });
+});
+
+test.describe('Live — showLiveCurrentTime', () => {
+  test.beforeEach(async ({ page }) => {
+    await loadExample(page, '/examples/live-show-current-time.html');
+  });
+
+  test('current time control is visible during live playback when showLiveCurrentTime is enabled', async ({ page }) => {
+    await clickPlay(page);
+    await waitForPlayback(page, 1);
+
+    await expect(page.locator(sel.currentTime)).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  test('current time value is non-zero during live playback', async ({ page }) => {
+    await clickPlay(page);
+    await waitForPlayback(page, 1);
+
+    const text = await page.locator(sel.currentTime).innerText();
+    expect(text).not.toBe('0:00');
   });
 });

--- a/e2e/source-fallback.spec.ts
+++ b/e2e/source-fallback.spec.ts
@@ -24,6 +24,22 @@ test.describe('Source fallback', () => {
     await expect(page.locator(sel.settings)).toBeVisible();
   });
 
+  // ── default enabled ────────────────────────────────────────────────────────
+
+  test('sourceFallback is enabled by default — no explicit config needed', async ({ page }) => {
+    await abortFirstSource(page);
+    await loadExample(page, PAGE);
+
+    // The fallback fires without sourceFallback being set in the config,
+    // because multiple <source> tags enable it automatically.
+    await page.waitForFunction(() => (window as unknown as Record<string, unknown>).__sourceFallbackPayload, {
+      timeout: 10_000,
+    });
+
+    const hasError = await page.evaluate(() => (window as unknown as Record<string, unknown>).__playerError);
+    expect(hasError).toBeFalsy();
+  });
+
   // ── fallback fires ─────────────────────────────────────────────────────────
 
   test('source:fallback event fires with the failed and next source URLs', async ({ page }) => {

--- a/examples/live-show-current-time.html
+++ b/examples/live-show-current-time.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>OpenPlayerJS — HLS live streaming playback</title>
+  <title>OpenPlayerJS — HLS live streaming with current time visible</title>
   <link rel="stylesheet" href="/packages/player/dist/openplayer.css" />
   <style>
     body { background: #111; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
@@ -15,13 +15,6 @@
       <source
         src="https://media-tyo.hls.nhkworld.jp/hls/w/live/master.m3u8"
         type="application/x-mpegURL"
-      />
-      <track
-        kind="subtitles"
-        src="/examples/captions/captions-en.vtt"
-        srclang="en"
-        label="English"
-        default
       />
     </video>
   </div>
@@ -42,6 +35,7 @@
 
     const media = document.querySelector('#player');
     const core = new Core(media, {
+      showLiveCurrentTime: true,
       plugins: [
         new HlsMediaEngine({ enableWorker: true, lowLatencyMode: false }),
       ],
@@ -50,7 +44,7 @@
     createUI(core, media, buildControls({
       top: ['progress'],
       'bottom-left': ['play', 'time', 'volume'],
-      'bottom-right': ['captions', 'settings', 'fullscreen'],
+      'bottom-right': ['settings', 'fullscreen'],
     }));
 
     window.__core = core;

--- a/examples/source-fallback.html
+++ b/examples/source-fallback.html
@@ -14,7 +14,8 @@
   <div id="wrap">
     <!--
       Two sources: the first is intentionally broken so the player falls back
-      to the second automatically when sourceFallback: true is set.
+      to the second automatically. sourceFallback is true by default when
+      multiple <source> tags are present — no extra config needed.
     -->
     <video id="player" class="op-player__media" controls playsinline muted>
       <source src="/broken-video-source.mp4" type="video/mp4" />
@@ -38,10 +39,7 @@
     const media = document.querySelector('#player');
     const status = document.querySelector('#status');
 
-    const core = new Core(media, {
-      sourceFallback: true,
-      plugins: [],
-    });
+    const core = new Core(media, { plugins: [] });
 
     core.on('source:fallback', (payload) => {
       window.__sourceFallbackPayload = payload;

--- a/packages/core/__tests__/core.player.branches.test.ts
+++ b/packages/core/__tests__/core.player.branches.test.ts
@@ -409,4 +409,64 @@ describe('core/player branches', () => {
 
     expect(seeks).toEqual([30]);
   });
+
+  // ── isLive from Infinity duration ─────────────────────────────────────────
+
+  test('isLive is set to true when durationchange fires with Infinity duration', async () => {
+    const media = document.createElement('video');
+    media.src = 'https://example.com/live.m3u8';
+    document.body.appendChild(media);
+
+    const p = new Core(media, { plugins: [new EngineA()] });
+    await Promise.resolve();
+
+    expect(p.isLive).toBe(false);
+
+    Object.defineProperty(media, 'duration', { value: Infinity, configurable: true });
+    p.events.emit('durationchange');
+
+    expect(p.isLive).toBe(true);
+
+    document.body.removeChild(media);
+  });
+
+  test('isLive resets to false when a new source is set via src setter', async () => {
+    const media = document.createElement('video');
+    media.src = 'https://example.com/live.m3u8';
+    document.body.appendChild(media);
+
+    const p = new Core(media, { plugins: [new EngineA()] });
+    await Promise.resolve();
+
+    Object.defineProperty(media, 'duration', { value: Infinity, configurable: true });
+    p.events.emit('durationchange');
+    expect(p.isLive).toBe(true);
+
+    Object.defineProperty(media, 'duration', { value: 120, configurable: true });
+    p.src = 'https://example.com/vod.mp4';
+    expect(p.isLive).toBe(false);
+
+    document.body.removeChild(media);
+  });
+
+  test('isLive resets to false at the start of each load() call', async () => {
+    const media = document.createElement('video');
+    media.src = 'https://example.com/live.m3u8';
+    document.body.appendChild(media);
+
+    const p = new Core(media, { plugins: [new EngineA()] });
+    await Promise.resolve();
+
+    Object.defineProperty(media, 'duration', { value: Infinity, configurable: true });
+    p.events.emit('durationchange');
+    expect(p.isLive).toBe(true);
+
+    (p as any).state.transition('idle');
+    Object.defineProperty(media, 'duration', { value: 300, configurable: true });
+    p.load();
+
+    expect(p.isLive).toBe(false);
+
+    document.body.removeChild(media);
+  });
 });

--- a/packages/core/__tests__/core.player.branches.test.ts
+++ b/packages/core/__tests__/core.player.branches.test.ts
@@ -469,16 +469,4 @@ describe('core/player branches', () => {
 
     document.body.removeChild(media);
   });
-
-  test('isLive is true immediately from constructor when config.duration is Infinity', () => {
-    const media = document.createElement('video');
-    media.src = 'https://example.com/live.m3u8';
-    document.body.appendChild(media);
-
-    const p = new Core(media, { plugins: [], duration: Infinity });
-
-    expect(p.isLive).toBe(true);
-
-    document.body.removeChild(media);
-  });
 });

--- a/packages/core/__tests__/core.player.branches.test.ts
+++ b/packages/core/__tests__/core.player.branches.test.ts
@@ -469,4 +469,16 @@ describe('core/player branches', () => {
 
     document.body.removeChild(media);
   });
+
+  test('isLive is true immediately from constructor when config.duration is Infinity', () => {
+    const media = document.createElement('video');
+    media.src = 'https://example.com/live.m3u8';
+    document.body.appendChild(media);
+
+    const p = new Core(media, { plugins: [], duration: Infinity });
+
+    expect(p.isLive).toBe(true);
+
+    document.body.removeChild(media);
+  });
 });

--- a/packages/core/__tests__/core.sourcefallback.test.ts
+++ b/packages/core/__tests__/core.sourcefallback.test.ts
@@ -54,15 +54,53 @@ describe('source fallback', () => {
     document.body.innerHTML = '';
   });
 
-  // ── default (disabled) ────────────────────────────────────────────────────
+  // ── default (enabled for <source> tags) ─────────────────────────────────
 
-  test('without sourceFallback, error transitions to error state immediately even with multiple sources', async () => {
+  test('sourceFallback is enabled by default: second <source> tag is tried after first fails', async () => {
+    const media = document.createElement('audio');
+    media.appendChild(makeAudioSource(1)); // fails
+    media.appendChild(makeVideoSource(1)); // succeeds
+    document.body.appendChild(media);
+
+    const p = new Core(media, { plugins: [new FailingEngine(), new SucceedingEngine()] });
+    await Promise.resolve();
+
+    expect(p.state.current).toBe('ready');
+  });
+
+  test('with sourceFallback: false, error transitions to error state immediately even with multiple sources', async () => {
     const media = document.createElement('audio');
     media.appendChild(makeAudioSource(1));
     media.appendChild(makeAudioSource(2));
     document.body.appendChild(media);
 
-    const p = new Core(media, { plugins: [new FailingEngine()] });
+    const p = new Core(media, { sourceFallback: false, plugins: [new FailingEngine()] });
+    await Promise.resolve();
+
+    expect(p.state.current).toBe('error');
+  });
+
+  test('single programmatic src does not trigger fallback even with default sourceFallback: true', async () => {
+    class HighPriorityFailingEngine {
+      name = 'hp-failing-engine';
+      version = '0';
+      capabilities = ['media-engine'];
+      priority = 999;
+      canPlay(_s: MediaSource) {
+        return true;
+      }
+      attach(ctx: MediaEngineContext) {
+        ctx.events.emit('error', null);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      detach() {}
+    }
+
+    const media = document.createElement('audio');
+    document.body.appendChild(media);
+
+    const p = new Core(media, { plugins: [new HighPriorityFailingEngine()] });
+    p.src = 'https://example.com/audio-1.mp3';
     await Promise.resolve();
 
     expect(p.state.current).toBe('error');

--- a/packages/core/src/core/configuration.ts
+++ b/packages/core/src/core/configuration.ts
@@ -10,4 +10,5 @@ export type PlayerConfig = {
 export const defaultConfiguration: PlayerConfig = {
   startTime: 0,
   duration: 0,
+  sourceFallback: true,
 };

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -63,7 +63,6 @@ export class Core {
     this.media.currentTime = this.config.startTime || this.media.currentTime;
     this._currentTime = this.config.startTime || this.activeSurface.currentTime;
     this._duration = this.config.duration || this.activeSurface.duration;
-    if (this._duration === Infinity) this.isLive = true;
 
     const initialVolume = clamp01(this.config.startVolume ?? this.activeSurface.volume);
     this.activeSurface.volume = initialVolume;

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -63,6 +63,7 @@ export class Core {
     this.media.currentTime = this.config.startTime || this.media.currentTime;
     this._currentTime = this.config.startTime || this.activeSurface.currentTime;
     this._duration = this.config.duration || this.activeSurface.duration;
+    if (this._duration === Infinity) this.isLive = true;
 
     const initialVolume = clamp01(this.config.startVolume ?? this.activeSurface.volume);
     this.activeSurface.volume = initialVolume;

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -141,6 +141,7 @@ export class Core {
         this.activeEngine = undefined;
         this.playerContext = null;
       }
+      this.isLive = false;
       this.state.transition('idle');
       this._currentTime = 0;
       this.readyPromise = undefined;
@@ -200,6 +201,7 @@ export class Core {
   load() {
     if (this.state.current !== 'idle') return;
 
+    this.isLive = false;
     this.emit('cmd:startLoad');
     this.createReadyPromise();
 
@@ -534,6 +536,7 @@ export class Core {
       try {
         const d = this.config.duration || this.activeSurface.duration;
         this._duration = d;
+        if (d === Infinity) this.isLive = true;
       } catch {
         // ignore
       }

--- a/packages/player/__tests__/player.controls.test.ts
+++ b/packages/player/__tests__/player.controls.test.ts
@@ -174,6 +174,19 @@ describe('UI Controls', () => {
     expect(el.getAttribute('aria-hidden')).toBe('false');
   });
 
+  test('CurrentTimeControl remains visible when isLive=true and showLiveCurrentTime is enabled', () => {
+    const v = document.createElement('video');
+    v.src = 'https://example.com/live.m3u8';
+    document.body.appendChild(v);
+    const p = new Core(v, { plugins: [], showLiveCurrentTime: true } as any);
+
+    const el = nn(createCurrentTimeControl()).create(p) as HTMLElement;
+
+    p.isLive = true;
+    p.events.emit('timeupdate');
+    expect(el.getAttribute('aria-hidden')).toBe('false');
+  });
+
   test('DurationControl shows LIVE label when isLive=true or duration=Infinity', () => {
     const p = makeCore();
     const el = nn(createDurationControl()).create(p) as HTMLElement;

--- a/packages/player/src/configuration.ts
+++ b/packages/player/src/configuration.ts
@@ -19,6 +19,7 @@ export type PlayerUIConfig = PlayerConfig & {
   allowSkip?: boolean;
   allowRewind?: boolean;
   speed?: SpeedConfig;
+  showLiveCurrentTime?: boolean;
 };
 
 export const DEFAULT_SPEED_RATES = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
@@ -69,6 +70,7 @@ export type ResolvedUIConfig = {
   allowRewind: boolean;
   step: number;
   speed: Required<SpeedConfig>;
+  showLiveCurrentTime: boolean;
   width?: string | number;
   height?: string | number;
   labels: Record<string, string>;
@@ -80,6 +82,7 @@ export function resolveUIConfig(coreOrConfig: Core | PlayerConfig): ResolvedUICo
   const allowSkip = (config as any).allowSkip ?? defaultUIConfiguration.allowSkip;
   const allowRewind = (config as any).allowRewind ?? defaultUIConfiguration.allowRewind;
   const step = (config as any).step ?? defaultUIConfiguration.step;
+  const showLiveCurrentTime = (config as any).showLiveCurrentTime ?? false;
   const width = (config as any).width;
   const height = (config as any).height;
 
@@ -98,10 +101,11 @@ export function resolveUIConfig(coreOrConfig: Core | PlayerConfig): ResolvedUICo
       (config as any).allowRewind = allowRewind;
       (config as any).step = step;
       (config as any).speed = speed;
+      (config as any).showLiveCurrentTime = showLiveCurrentTime;
     } catch {
       // ignore
     }
   }
 
-  return { allowSkip, allowRewind, step, speed, width, height, labels };
+  return { allowSkip, allowRewind, step, speed, showLiveCurrentTime, width, height, labels };
 }

--- a/packages/player/src/controls/currentTime.ts
+++ b/packages/player/src/controls/currentTime.ts
@@ -1,6 +1,7 @@
 import { formatTime, generateISODateTime } from '@openplayerjs/core';
 import type { Control } from '../control';
 import { BaseControl } from './base';
+import { resolveUIConfig } from '../configuration';
 
 export class CurrentTimeControl extends BaseControl {
   id = 'currentTime';
@@ -8,6 +9,7 @@ export class CurrentTimeControl extends BaseControl {
 
   protected build(): HTMLElement {
     const core = this.core;
+    const { showLiveCurrentTime } = resolveUIConfig(core);
 
     const el = document.createElement('time');
     el.className = 'op-controls__current';
@@ -24,7 +26,7 @@ export class CurrentTimeControl extends BaseControl {
         return;
       }
 
-      if (core.isLive) {
+      if (core.isLive && !showLiveCurrentTime) {
         el.setAttribute('aria-hidden', 'true');
         return;
       }


### PR DESCRIPTION
## Summary

- **`sourceFallback` defaults to `true`** — multiple `<source>` tags now automatically fall back to the next source on error, matching native browser behaviour. No config needed. Opt out explicitly with `sourceFallback: false`. Single programmatic sources (`p.src = '...'`) are unaffected — the existing `detectedSources.length <= 1` guard prevents any retry.

- **`isLive` auto-detected from `Infinity` duration** — `Core.bindSurfaceSync` sets `isLive = true` whenever `durationchange` (or `loadedmetadata` / `timeupdate`) reports `Infinity`. This acts as a general safety net for engines that don't manage `isLive` explicitly (e.g. `DefaultMediaEngine` serving native HLS in Safari). For HLS.js streams the check is redundant but harmless — `LEVEL_LOADED` and `LEVEL_UPDATED` already set `isLive` authoritatively from the manifest, and both paths agree on the value. `load()` and the `src` setter reset `isLive = false` before each new source.

- **`showLiveCurrentTime` config option** — `PlayerUIConfig` gains `showLiveCurrentTime?: boolean` (default `false`). When `true`, `CurrentTimeControl` stays visible with the live-edge position instead of hiding during live playback.

## Changed files

| File | Change |
|------|--------|
| `packages/core/src/core/configuration.ts` | `sourceFallback: true` in `defaultConfiguration` |
| `packages/core/src/core/index.ts` | `isLive = false` reset in `load()` and `src` setter; `if (d === Infinity) isLive = true` in `bindSurfaceSync` |
| `packages/player/src/configuration.ts` | `showLiveCurrentTime` in `PlayerUIConfig`, `ResolvedUIConfig`, and `resolveUIConfig()` |
| `packages/player/src/controls/currentTime.ts` | Live guard: `if (core.isLive && !showLiveCurrentTime)` |
| `packages/core/__tests__/core.sourcefallback.test.ts` | Default-enabled test; explicit-false test; single-programmatic-src test |
| `packages/core/__tests__/core.player.branches.test.ts` | `isLive` lifecycle tests (durationchange, src setter reset, load() reset) |
| `packages/player/__tests__/player.controls.test.ts` | `showLiveCurrentTime` visibility test |
| `e2e/live.spec.ts` | `isLive` flag check; current time hidden by default; `showLiveCurrentTime` visible + non-zero |
| `e2e/source-fallback.spec.ts` | Default-enabled E2E test (no explicit config) |
| `e2e/helpers/player.ts` | `currentTime` selector |
| `examples/live.html` | `window.__core` exposed for E2E |
| `examples/live-show-current-time.html` | New example with `showLiveCurrentTime: true` |
| `examples/source-fallback.html` | Dropped explicit `sourceFallback: true` (now the default) |

## Test plan

- [x] `pnpm run build` — clean build across all packages
- [x] `pnpm run type-check` — no type errors
- [x] `pnpm run test` — 1148 unit tests pass
- [x] `pnpm run test:e2e` — 77 E2E tests pass (4 new live-stream tests against `https://media-tyo.hls.nhkworld.jp/hls/w/live/master.m3u8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)