### PR TITLE
docs: rewrite CLAUDE.md as an operating manual and add AI skills

### DIFF
--- a/.claude/skills/add-event/SKILL.md
+++ b/.claude/skills/add-event/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: add-event
+description: Add, rename, change the payload of, or remove a typed player event in OpenPlayerJS. Use whenever a task involves PlayerEventPayloadMap, EventBus events, cmd:* commands, ads:* events, or "emit/listen to X". Encodes the core-vs-package routing decision, declaration merging, payload conventions, and the safe-removal procedure.
+---
+
+# Add / change / remove a player event
+
+Events are the most rule-dense surface in this repo. Every step below exists because skipping
+it has broken something before. Work through the steps in order; do not improvise.
+
+## Step 0 — Classify the event
+
+Answer one question: **who emits it?**
+
+| Emitter | Classification | Where the type goes |
+| ------- | -------------- | ------------------- |
+| `Core`, `StateManager`, surfaces, `DefaultMediaEngine`, track plumbing | **Kernel event** | `PlayerEventPayloadMap` interface in `packages/core/src/core/events.ts` |
+| Any other package (ads, player UI, hls, youtube, external plugins) | **Package event** | That package's `src/events.ts` declaration-merging augmentation |
+
+Hard rules:
+- Core's map may contain ONLY: lifecycle, `cmd:*` commands, HTML5-native names (`playing`,
+  `pause`, `ended`, `loadedmetadata`, …), track events, `source:set`, `player:interacted`.
+- If you find yourself editing `packages/core/src/core/events.ts` for an `ads:*`, `hls:*`,
+  `ui:*`, or `zoom:*` key — stop, you are in the wrong file.
+- If the emitting package is unclear (e.g. core emits it but only ads consumes it), it is a
+  kernel event only if core can describe the payload without importing any package concept.
+  Otherwise redesign so the package emits it.
+
+## Step 1 — Name and shape the payload
+
+Naming:
+- `cmd:<verb>` — player→engine command (`cmd:play`, `cmd:seek`). Kernel only.
+- `<pkg-prefix>:<noun>[:<phase>]` — package events (`ads:break:start`, `ui:menu:open`).
+- Never a bare untyped string; never dot-notation (`ads.foo` was migrated away — colon only).
+
+Payload conventions (follow existing shapes, don't invent parallel ones):
+- A break descriptor is `{ id: string; kind: string }` carried under a `break` property.
+- Flat id references use `breakId` (e.g. `ads:quartile: { breakId, quartile: 25|50|75|100 }`).
+- Paired events (`X:open`/`X:close`, `X:start`/`X:end`) must both exist and both be emitted —
+  the player package relies on pairing (e.g. menu open/close gates the auto-hide timer).
+- Error payloads: `{ reason?, error?, message?, owner? }` (see `ads:error`).
+
+## Step 2 — Declare the type
+
+**Kernel event:** add the key to the `PlayerEventPayloadMap` interface in
+`packages/core/src/core/events.ts`. Do not convert the interface to a `type` — it is the one
+sanctioned interface (declaration merging requires it).
+
+**Package event:** edit (or create) `packages/<pkg>/src/events.ts`:
+
+```ts
+import '@openplayerjs/core';
+
+declare module '@openplayerjs/core' {
+  // eslint note: this augments core's sanctioned interface
+  interface PlayerEventPayloadMap {
+    'my:event': MyPayload;
+  }
+}
+```
+
+Then verify the side-effect import exists in `packages/<pkg>/src/index.ts`:
+
+```ts
+import './events';
+```
+
+If you created `events.ts` and forget this import, everything compiles locally but consumers
+of the published package silently lose the typing. Check it explicitly.
+
+If the package keeps a union of its own events (ads has `AdsEvent` in `src/types.ts`), update
+it in the same commit — the augmentation and the union must stay in sync.
+
+Special case — HLS: it deliberately has NO `events.ts`. It drives the player through standard
+core events only. Before adding an HLS event, confirm a real consumer exists (three HLS events
+were removed in Jun 2026 because nothing listened). Duration/live/ID3 metadata already flow
+through native channels — do not re-add events for them.
+
+## Step 3 — Emit and consume
+
+- Emit: `ctx.events.emit('my:event', payload)` — payload type is enforced.
+- Subscribe in a plugin: `ctx.on('my:event', cb)` (auto-disposed) — never a bare
+  `events.on` without registering the unsubscriber in `ctx.dispose`.
+- Subscribe in a control: `this.onPlayer('my:event', cb)`.
+- Timing rule: if the emit sits anywhere in the `Core.play()` → `cmd:play` path, it must not
+  introduce an `await`/microtask before `cmd:play` fires (Safari user-gesture context).
+
+## Step 4 — Test
+
+Minimum tests for a new event (in the owning package's `__tests__/`):
+1. Emission: drive the real trigger (not the emit itself) and assert the callback got the
+   exact payload shape — assert every property, not just truthiness.
+2. Typing: subscribing through `core.on('my:event', (p) => …)` compiles with the precise
+   payload type (this is implicit if the test file uses the typed callback).
+3. Pairing/cleanup, when applicable: the paired close/end event fires; unsubscribe on destroy.
+
+## Step 5 — Document
+
+- Add the event to the owning package's README event table (payload shape included).
+- If the event encodes a behavioral rule (ordering, pairing, sync requirement), add one line
+  to that package's `CLAUDE.md`.
+
+## Renaming or changing a payload
+
+This is a **breaking change** for downstream consumers. Stop and confirm with the user
+before doing it (manual §7 E1). Once approved:
+1. Change type + all emit sites + all subscribe sites in one commit.
+2. `grep -rn "'old:name'" packages/` until it returns nothing. If `.claude/CLAUDE.local.md`
+   lists other local consumer repos, grep and type-check those per its instructions.
+3. Run `pnpm run type-check`.
+4. Commit as `feat(<scope>)!:` or include a `BREAKING CHANGE:` footer so the release
+   orchestrator bumps major.
+
+## Removing an event
+
+Never trust "no typed listener" as proof of death — tests subscribe by string.
+1. `grep -rn "'the:event'" packages/` — check src, `__tests__/`, `e2e/`, `examples/`.
+2. Same grep in any local consumer repos listed in `.claude/CLAUDE.local.md`, if present.
+3. Only when all hits are the emit itself: delete the emit, the type entry, and the union
+   entry together. If the package's `events.ts` becomes empty, delete the file AND its
+   `import './events'` line.
+4. Run the full test suite; a hanging/timing-out test means you missed a subscriber.
+
+## Final checklist
+
+- [ ] Type declared in the correct home (kernel map vs package augmentation)
+- [ ] `import './events'` present in the package's `index.ts` (package events)
+- [ ] Package event-union (e.g. `AdsEvent`) updated if one exists
+- [ ] Emission test asserts the full payload shape
+- [ ] README event table updated
+- [ ] `pnpm run type-check && pnpm run lint && pnpm run test` green
+- [ ] Breaking change? → user approved + both monorepos type-check + `!`/footer in commit

--- a/.claude/skills/preship/SKILL.md
+++ b/.claude/skills/preship/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: preship
+description: Run the full OpenPlayerJS verification gauntlet before committing, opening a PR, or preparing a release. Use when the user says "verify", "is this ready", "run the checks", "prepare the release", or when finishing any non-trivial change. Covers build, type-check, lint, tests+coverage, generated-file hygiene, downstream-consumer checks, e2e, and release dry-run.
+---
+
+# Preship — verification gauntlet
+
+Run the applicable tier completely. Report every failure verbatim; never summarize a red
+gate as "mostly passing." A tier is green only when every command in it exited 0.
+
+## Tier 1 — every change (always run)
+
+Run these from the repo root, in this order (order matters: build regenerates the types the
+tests and dist checks depend on):
+
+```sh
+pnpm run type-check
+pnpm run lint
+pnpm run build
+pnpm run test
+```
+
+Then verify hygiene:
+
+1. **Coverage** — the `pnpm run test` summary must show ≥85% for branches, functions, lines,
+   and statements globally. If a metric dropped below, add tests (see the `write-tests`
+   skill); never lower a threshold or add a coverage exclusion — that is an ask-first change.
+2. **No generated files in the diff** — `git status --porcelain` must show no changes under
+   `dist/`, `coverage/`, `playwright-report/`, `test-results/`, or to `CHANGELOG.md`.
+   `pnpm-lock.yaml` may change only if the task added/updated a dependency (which itself
+   requires user approval).
+3. **No new escape hatches** — on the changed files:
+   ```sh
+   git diff -U0 master... -- packages/ | grep -nE '^\+.*(as any|@ts-ignore|@ts-expect-error|eslint-disable)'
+   ```
+   Every hit must match a sanctioned pattern (opaque alias for untyped external libs;
+   experimental browser APIs) and carry an inline justification comment. Anything else: fix
+   with a typed alternative from CLAUDE.md R4.
+4. **Core bundle isolation** — if the change touched core's public surface or any rollup
+   config, confirm core is still external:
+   ```sh
+   grep -l "class EventBus" packages/{hls,ads,player,youtube}/dist/*.js
+   ```
+   Any hit means core got bundled into a consumer package — a build config regression.
+
+## Tier 2 — core/player public types changed
+
+Trigger: the diff touches any exported type, class signature, or `PlayerEventPayloadMap` in
+`packages/core` or `packages/player`.
+
+- Public-surface changes are breaking for downstream consumers that pin exact versions. If
+  `.claude/CLAUDE.local.md` lists local consumer repos with verification steps, run them now.
+  If a downstream check fails: **do not** edit that repo unless the task included it. Report
+  the exact errors to the user and ask how to proceed (fix downstream vs revise the API here).
+- Also confirm the API diff is intentional: after `pnpm run build`, run
+  `git diff --stat -- '*/dist/types/*' 2>/dev/null || true` mentally against the task — every
+  changed declaration file should map to something the task asked for.
+
+## Tier 3 — user-visible behavior changed
+
+Trigger: the change affects what plays, renders, or responds to input in a browser (UI
+controls, engines, ads flow, autoplay, fullscreen).
+
+```sh
+pnpm run test:e2e
+```
+
+- E2E specs live in `e2e/*.spec.ts` and load pages from `examples/*.html`. If the change adds
+  user-visible behavior with no covering spec, write one (pattern-match the closest existing
+  spec, e.g. `e2e/src-switch.spec.ts`) and add/extend an example page.
+- Playwright flakes: retry a failing spec once in isolation
+  (`pnpm exec playwright test e2e/foo.spec.ts`) before treating it as a real failure; if it
+  fails twice, it is real — report it.
+
+## Tier 4 — release preparation (only when explicitly asked to prepare a release)
+
+Pre-conditions: Tiers 1–3 green, working tree clean, on `master` (or the user named a branch).
+
+```sh
+pnpm run preflight
+pnpm run release:dry-run
+```
+
+Review the dry-run output against these expectations and report discrepancies:
+- **Core changed since last tag** → core releases first, then player/hls/ads/youtube ALL at
+  the same version (lockstep). One version number across the family.
+- **Core unchanged** → only packages with their own commits since their last per-package tag
+  appear.
+- Bump size matches the conventional commits since the last tag (`feat`→minor, `fix`→patch,
+  breaking→major). If the user wants a different bump, the command is
+  `release:minor`/`release:major` — never a hand-edited version field.
+
+**Hard stop:** never run `pnpm run release` (or any non-`:dry-run` variant), `npm publish`,
+or `git push` without the user explicitly instructing it in this session. Publishing is
+irreversible. Present the dry-run summary and wait.
+
+## Reporting format
+
+End with a table: one row per gate actually run, columns = gate, command, result
+(pass / fail + one-line reason). Below it, verbatim output for every failure, then the
+single next action you recommend. If everything passed, say what tier was run and that the
+change is ready for commit/PR/release respectively.

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: write-tests
+description: Write or extend Jest tests for OpenPlayerJS to this repo's exact conventions — makeCore factories, typed internals handles instead of `as any`, media property mocking, fake timers, ads/vast mocks, and coverage-gap targeting. Use when asked to add tests, raise coverage, fix the 85% threshold, or when a bug fix needs its regression test.
+---
+
+# Write tests the OpenPlayerJS way
+
+Tests here are the executable spec and are lint-clean (zero `no-explicit-any` warnings in
+`__tests__/` — a state that took a 394-warning sweep to reach; do not regress it). Follow
+this playbook exactly.
+
+## Step 0 — Target the right gap
+
+- Regression test for a bug fix: write it FIRST, confirm it fails on the pre-fix code
+  (`git stash` the fix if needed), then confirm it passes after.
+- Coverage work: find the actual uncovered branches, don't guess:
+  ```sh
+  pnpm run test 2>/dev/null | tail -40          # per-file summary
+  # then open coverage/lcov-report/<pkg>/<file>.html or:
+  pnpm exec jest packages/<pkg> --coverage --collectCoverageFrom='packages/<pkg>/src/**'
+  ```
+- Skip what's excluded by design: the youtube package, `umd.ts`, `index.ts` barrels, and the
+  documented-unreachable CSAI paths (SIMID/OMID/real-browser HLS) — don't burn time there.
+
+## Step 1 — File placement and skeleton
+
+- Location: `packages/<pkg>/__tests__/`. Naming: `feature.test.ts` for main coverage,
+  `feature.branches.test.ts` for edge/error paths, scenario-named files for specific
+  behaviors (`player.autoplay.unmute.test.ts`).
+- Every file starts with the environment pragma and uses local factories:
+
+```ts
+/** @jest-environment jsdom */
+import { Core } from '@openplayerjs/core'; // always the package alias, never relative
+
+describe('Feature name', () => {
+  function makeCore() {
+    const v = document.createElement('video');
+    v.src = 'https://example.com/video.mp4';
+    document.body.appendChild(v);
+    return new Core(v, { plugins: [] }); // explicit empty plugins — no accidental engines
+  }
+
+  function nn<T>(v: T | null | undefined): T {
+    expect(v).toBeTruthy();
+    return v as T;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+});
+```
+
+No module-level mutable state. Anything shared goes inside the describe as a factory.
+
+## Step 2 — Standard levers
+
+**Readiness / playback state** (mediaMocks from `__tests__/setup/mediaMocks.ts` is already
+loaded globally — play/pause/load/canPlayType are mocked):
+
+```ts
+p.events.emit('loadedmetadata');            // resolves whenReady()
+p.events.emit('playing');                   // drive state transitions
+```
+
+**Synchronous play/pause for UI tests:**
+
+```ts
+p.play = jest.fn(async () => { p.events.emit('playing'); }) as unknown as Core['play'];
+p.pause = jest.fn(() => { p.emit('cmd:pause'); p.events.emit('pause'); }) as unknown as Core['pause'];
+```
+
+**Read-only media properties — always defineProperty, always configurable:**
+
+```ts
+Object.defineProperty(p.media, 'duration', { value: 120, configurable: true });
+Object.defineProperty(p.media, 'paused', { value: false, configurable: true });
+```
+
+**Timers:** `jest.useFakeTimers()` at the top of the describe; drive with
+`jest.advanceTimersByTime(ms)`; flush microtask-based logic with `await Promise.resolve()`.
+Never a real `setTimeout` wait.
+
+**jsdom quirks:** patch `window.scrollX/scrollY` (the source reads these, not
+`pageXOffset`); `queueMicrotask`-based focus handlers need a microtask flush, not a timer.
+
+## Step 3 — Typed access instead of `as any` (mandatory)
+
+| Need | Pattern |
+| ---- | ------- |
+| `@internal` getters on a plugin | `type AdsPluginInternals = AdsPlugin & { bus: NonNullable<AdsPlugin['bus']>; active: boolean };` then `as unknown as AdsPluginInternals`. `@internal` **methods** are public — call them directly, no cast. |
+| `private` members | `as unknown as { member: T }` — an intersection `Class & { privateMember }` reduces to `never`; the double cast is the only way. |
+| Partial mock context | `const ctx = {...} as unknown as PluginContext;` — and keep `on:` a single non-overloaded impl so contextual typing works. |
+| Window/global stubs | One local shape per file: `const win = window as unknown as { YT?: { Player: jest.Mock } };` assign/delete through it. |
+| Custom cue props | `type RawCue = TextTrackCue & { data?: ArrayBuffer; value?: unknown; scte35Out?: string };` |
+| Vendor DOM APIs | `type VendorElement = HTMLElement & { webkitEnterFullscreen?: () => void };` |
+| Config extras | Cast to the real config type: `{ plugins: [], step: 10 } as PlayerUIConfig` — never `as any`. |
+| Wrong-type mock returns | `mockResolvedValue(undefined as unknown as boolean)` when the signature demands it. |
+
+## Step 4 — Package-specific rules
+
+**ads** — never import `@dailymotion/vast-client` or `@dailymotion/vmap`; jest's
+`moduleNameMapper` routes them to `packages/ads/__tests__/mocks/` (the mocks export shared
+`jest.fn()` instances — reset them in `beforeEach`). VAST XML fixtures live in
+`packages/ads/__tests__/fixtures/ads/*.xml`; add a fixture rather than inlining XML. Break
+configs passed to typed methods need an explicit annotation
+(`const brk: AdsBreakConfig = { at: 0, source: { type: 'VAST', … } }`) or the `type` literal
+widens to `string`.
+
+**hls** — mock event names as constants OUTSIDE the `jest.mock()` factory
+(`const E = { MANIFEST_PARSED: 'MANIFEST_PARSED' } as const`); get the mock instance via
+`engine.getAdapter<HlsMockWithEmit>()` and `adapter!.emit(E.MANIFEST_PARSED, null, {})`.
+Keep `.on/.emit` as method calls on the cast object so `this` stays bound.
+
+**youtube / iframe** — stub the adapter, not the network: a `StubAdapter implements
+IframeMediaAdapter` with a `Map<string, Function>` listener registry and jest.fn methods;
+fake the API global via a typed window handle (`win.YT = { Player: jest.fn(...) }`).
+
+**player controls** — build through the real factory, drive with dispatched DOM events
+(`el.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }))`), and assert on DOM state +
+emitted player events, not on private fields, unless a private is the only observable.
+
+## Step 5 — Assert like the spec
+
+- Assert exact payloads and full shapes (`toEqual({ id: 'brk-1', kind: 'preroll' })`), not
+  `toHaveBeenCalled()` alone.
+- Every error/early-return branch you're covering gets its own `test()` with a name that
+  states the behavior ("does not resume content between waterfall attempts"), not the
+  implementation ("calls startBreak with flag").
+- Clean up what you create: if the test attaches engines, mounts UI, or acquires leases,
+  destroy the player at the end so cross-test leaks can't hide.
+
+## Step 6 — Verify
+
+```sh
+pnpm exec jest packages/<pkg>/__tests__/<file>.test.ts   # the new file, fast loop
+pnpm run test                                            # full suite + 85% coverage gates
+pnpm run lint                                            # zero new warnings, incl. no-explicit-any
+pnpm run type-check
+```
+
+A test that passes but emits lint warnings or needs `as any` is not done. A suite that hangs
+or times out after your change usually means you removed/renamed an event a test subscribes
+to — grep the event name across `packages/` before anything else.

--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ playwright-report/
 !examples/**/*.vtt
 
 # AI
-.claude
+CLAUDE.local.md
+.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,510 +1,279 @@
-# OpenPlayerJS — Code Practices & Development Guide
+# OpenPlayerJS — Operating Manual
 
-## Repository Overview
+This file is the contract for working in this repo. It states rules, the mistakes those rules
+prevent, checkable quality gates per kind of change, and exactly when to stop and ask.
+Package-level detail lives in `packages/*/CLAUDE.md` — **read the package's CLAUDE.md before
+editing any file in that package.** That is not optional; each one documents load-bearing
+behavior that is invisible from the code alone.
 
-Monorepo managed with **pnpm workspaces** and **Turbo**. All source lives under `packages/`; the root contains only shared config.
+## 1. What this repo is
 
-```
-packages/
-  core/      — Player, EventBus, engines, plugin system, state, overlays
-  player/    — UI controls, createUI(), style.css  (@openplayerjs/player)
-  hls/       — HlsMediaEngine (wraps hls.js)
-  ads/       — AdsPlugin, strategies (CSAI/SSAI/Hybrid)
-  youtube/   — YouTubeMediaEngine + YouTubeIframeAdapter
-```
+HTML5 video/audio player. Monorepo: **pnpm workspaces + Turbo + TypeScript 6 (strict)**. All
+source under `packages/`; the root holds only shared config and scripts.
 
----
+| Package   | Role                                                                                                      | Detail file                  |
+| --------- | --------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `core`    | Kernel: `Core`, `EventBus`, `BaseMediaEngine`, plugins, state, overlays, surfaces. **Zero runtime deps.** | `packages/core/CLAUDE.md`    |
+| `player`  | UI layer: `createUI()`, controls, CSS, a11y, UMD `Player`                                                 | `packages/player/CLAUDE.md`  |
+| `hls`     | `HlsMediaEngine` wrapping hls.js (priority 50)                                                            | `packages/hls/CLAUDE.md`     |
+| `ads`     | `AdsPlugin` + CSAI/SSAI/Hybrid strategies                                                                 | `packages/ads/CLAUDE.md`     |
+| `youtube` | `YouTubeMediaEngine` + iframe adapter (priority 100)                                                      | `packages/youtube/CLAUDE.md` |
 
-## Local Development
+Dependency direction is strictly one-way: everything depends on `core`; `core` depends on
+nothing and knows nothing about the packages above it. Architecture rationale: `ARCHITECTURE.md`.
 
-```sh
-pnpm install          # install all workspace deps
-pnpm run build        # full build (required before running tests)
-pnpm run watch        # incremental rebuild on file changes (Turbo watch)
-pnpm run test         # Jest with coverage
-pnpm run test:watch   # Jest in watch mode
-pnpm run lint         # ESLint + stylelint
-pnpm run type-check   # tsc --noEmit across all packages
-pnpm run preflight    # pre-release sanity check script
-```
+Published packages have external consumers that pin exact versions. Any change to a core
+public type, `PlayerEventPayloadMap`, or an exported signature can break downstream code
+silently — treat public-surface changes as breaking (see §7 E1). If a
+`.claude/CLAUDE.local.md` exists, it lists additional local-only context and checks; follow it.
 
-For E2E testing (Playwright):
-
-```sh
-pnpm run test:e2e           # headless
-pnpm run test:e2e:ui        # with Playwright UI
-pnpm run test:e2e:debug     # debug mode
-```
-
----
-
-## Releases
-
-Releases are automated via `scripts/orchestrate-release.cjs` using conventional commits.
-
-**Rules:**
-- Core changed → release core first, then **all dependents at the same version** (lockstep). All packages share one version number.
-- Core unchanged → release only packages that have their own changes since their last tag.
+## 2. Commands (the only sanctioned entry points)
 
 ```sh
-pnpm run release              # patch bump (default)
-pnpm run release:minor        # minor bump
-pnpm run release:major        # major bump
-pnpm run release:dry-run      # preview without writing anything
-pnpm run release:pack         # pack all packages to ./packed/ (for local testing)
+pnpm install               # workspace deps
+pnpm run build             # clean → build:types → turbo bundles+css. REQUIRED before tests.
+pnpm run watch             # incremental rebuild
+pnpm run test              # Jest + coverage (85% global threshold)
+pnpm run test:watch
+pnpm run lint              # ESLint (flat) + stylelint
+pnpm run type-check        # tsc --noEmit, all packages
+pnpm run preflight         # workspace sanity gate (also first step of release)
+pnpm run test:e2e          # Playwright (headless); :ui / :debug variants exist
+pnpm run release:dry-run   # preview release; NEVER run non-dry release unprompted (E1)
 ```
 
-Bump type is inferred from conventional commit prefixes (`feat:` → minor, `fix:` → patch, `BREAKING CHANGE` → major). Pass `--increment` to override.
+Run a single test file with `pnpm exec jest packages/ads/__tests__/ads.test.ts`. Never bypass
+these scripts with hand-rolled tsc/rollup/jest invocations that use different configs.
 
----
+## 3. Non-negotiable rules — each exists because the mistake actually happened
 
-## TypeScript Conventions
+Each entry: the mistake a model will make → the rule that prevents it.
 
-### Strict mode is non-negotiable
+**R1 — Putting package events in core.**
+You will be tempted to add `ads:*`, `hls:*`, or `ui:*` keys to `PlayerEventPayloadMap` in
+`packages/core/src/core/events.ts` because "that's where events live." **Never.** Core declares
+only kernel events (lifecycle, `cmd:*`, HTML5-native names, tracks, `source:set`,
+`player:interacted`). Package events are added by **declaration merging**: the owning package's
+`src/events.ts` contains `declare module '@openplayerjs/core' { interface PlayerEventPayloadMap
+{ 'my:event': MyPayload } }` and is side-effect-imported from that package's `index.ts`
+(`import './events';` — forget this import and consumers lose the types silently). Canonical
+example: `packages/ads/src/events.ts`. HLS deliberately augments nothing.
 
-All packages compile with `"strict": true` and **TypeScript 6**. No `any` without justification. Use `unknown` for unknowns.
+**R2 — `PlayerEventPayloadMap` is the ONE sanctioned `interface`.**
+ESLint enforces `type` over `interface` everywhere. `PlayerEventPayloadMap` is an `interface`
+(with inline eslint-disable) because only interfaces can be merged across modules. Do not
+"fix" it to a `type`; do not use this exception as precedent for other interfaces.
 
-### Never add `as any` — use typed alternatives
+**R3 — Never remove an event emission as "dead code" without grepping tests.**
+An emit with no typed listener in src may still have subscribers in `__tests__/`. Removing
+`ads.allAdsCompleted` this way once broke a VMAP integration test with a silent timeout.
+Before deleting any `emit('X', …)`: `grep -rn "'X'" packages/` and check every hit.
 
-`as any` defeats the type system and hides real errors. Prefer:
+**R4 — No new `as any`. Use the typed alternative for the situation:**
 
 ```ts
-// Vendor-prefixed / non-standard browser APIs → typed intersection
+// Vendor-prefixed browser APIs → typed intersection
 type VendorElement = HTMLElement & { webkitEnterFullscreen?: () => void };
-const el = target as VendorElement;
-
-// Non-standard DOM properties (e.g. DataCue, TextTrackCue extensions) → local typed alias
+// Non-standard cue/DOM props → local alias
 type RawCue = TextTrackCue & { data?: ArrayBuffer; value?: unknown };
-const raw = cue as RawCue;
-
-// Opaque objects that need structural access → minimal typed interface
-type PlayerLike = { events?: { on?: unknown; emit?: unknown } };
-const p = player as PlayerLike;
-
-// Private method access in tests → typed handle alias
-type ControlInternals = ReturnType<typeof createControl> & { resolveRoot(): HTMLElement };
-const c = control as unknown as ControlInternals;
-
-// Read-only HTMLMediaElement properties in tests → Object.defineProperty
+// Read-only media props in tests → defineProperty, never assignment
 Object.defineProperty(media, 'duration', { value: 120, configurable: true });
+// Private member access in tests → double cast to a minimal shape
+const c = control as unknown as { resolveRoot(): HTMLElement };
+// NOTE: `Class & { privateMember: T }` intersections reduce to `never` for
+// private members — you MUST use `as unknown as { member: T }` instead.
+// Permissive event-callback params → non-optional `never` (contravariance):
+on(event: string, cb: (payload: never) => void): () => boolean;
+// `(payload?: never)` does NOT work — the `?` widens to undefined.
 ```
 
-Justified `as any` exceptions (document with an inline comment):
-- Experimental browser APIs not yet in TypeScript's lib (e.g. `window.screen.orientation.lock`)
-- Generic event forwarding loops over third-party typed event enums (hls.js)
-- External library outputs with no shipped types (OMID, SIMID, `@dailymotion/vast-client` parsed objects)
-
-### `type` over `interface` — enforced by ESLint
-
-```ts
-// CORRECT
-export type PlayerPlugin = { name: string; setup?(ctx: PluginContext): void };
-
-// WRONG — ESLint will reject this
-export interface PlayerPlugin {
-  name: string;
-}
-```
-
-### `import type` for type-only imports — enforced by ESLint
-
-```ts
-import type { MediaSource } from '../core/media'; // type import
-import { EventBus } from '../core/events'; // value import
-```
-
-### Naming
-
-| Construct            | Convention                      | Example                                    |
-| -------------------- | ------------------------------- | ------------------------------------------ |
-| Files (multi-word)   | kebab-case                      | `event-bus.ts`, `media-engine.ts`          |
-| Classes              | PascalCase                      | `EventBus`, `BaseMediaEngine`, `AdsPlugin` |
-| Methods / properties | camelCase                       | `canPlay()`, `bindSurfaceEvents()`         |
-| Constants            | UPPER_SNAKE_CASE                | `DVR_THRESHOLD`, `OVERLAY_MANAGER_KEY`     |
-| Private fields       | `private` keyword or `#` prefix | `private readonly surface`                 |
-
-### Access modifiers
-
-Always declare access modifiers explicitly. Use `readonly` whenever a field is never reassigned.
-
-```ts
-export abstract class BaseMediaEngine {
-  protected surface: MediaSurface | null = null; // subclasses can read
-  private surfaceListeners: (() => void)[] = []; // internal only
-  abstract name: string; // subclass must define
-}
-```
-
-### Error handling
-
-Use try/catch for defensive cleanup — a broken plugin must not crash the player:
-
-```ts
-for (const p of this.plugins) {
-  try {
-    p.destroy?.();
-  } catch {
-    /* ignore */
-  }
-}
-```
-
-Only validate at system boundaries (user input, external APIs). Don't add validation for impossible states.
-
----
-
-## Architecture Patterns
-
-### Engine pattern — `BaseMediaEngine`
-
-All media engines extend `BaseMediaEngine` (`packages/core/src/engines/base.ts`).
-
-Required abstract members:
-
-```ts
-abstract name: string;
-abstract version: string;
-abstract capabilities: string[];
-abstract priority: number;             // higher = preferred; HLS=50, HTML5=0
-abstract canPlay(src: MediaSource): boolean;
-abstract attach(ctx: MediaEngineContext): void | Promise<void>;
-abstract detach(): void;
-```
-
-Lifecycle helpers to use (not override):
-
-- `bindSurfaceEvents(surface, events)` — bridges surface events to EventBus
-- `unbindSurfaceEvents()` — cleanup alias
-- `bindCommands(ctx)` — subscribes to `cmd:*` events; results stored in `this.commands`
-- `bindMediaEvents(media, events)` — bridges native HTMLMediaElement events
-- `unbindMediaEvents()` — cleanup alias
-
-### Plugin pattern — `PlayerPlugin`
-
-```ts
-export type PlayerPlugin = {
-  name: string;
-  version: string;
-  capabilities?: string[]; // e.g. ['media-engine'], ['ads']
-  setup?(ctx: PluginContext): void;
-  onEvent?(event: PlayerEvent, payload?: unknown): void;
-  destroy?(): void;
-};
-```
-
-`PluginContext` provides:
-
-- `events: EventBus` — subscribe to typed player events
-- `state: StateManager<PlaybackState>` — current playback state + transitions
-- `leases: Lease` — acquire exclusive capability ownership
-- `core: Core` — player instance reference
-- `dispose: DisposableStore` — register cleanup callbacks; called on player destroy
-- Convenience: `ctx.on()`, `ctx.listen()`, `ctx.add()`
-
-**Rule**: Register all subscriptions through `ctx.dispose` so they are automatically cleaned up.
-
-### Event system — `EventBus`
-
-Events are fully typed via `PlayerEventPayloadMap`. Never emit or listen to untyped strings.
-
-```ts
-// Subscribe (returns unsubscribe fn)
-const off = events.on('cmd:play', () => media.play());
-
-// Emit
-events.emit('media:timeupdate', currentTime);
-```
-
-#### Package boundary — core stays agnostic of package events (CRITICAL)
-
-`PlayerEventPayloadMap` lives in core and declares **only kernel-level events** (lifecycle, commands, HTML5 media notifications, tracks). **Core must never gain `hls:*`, `ads:*`, `ui:*`, or any other package-specific keys.** This preserves the hierarchy: core is the kernel, player is the UI layer, and engines/plugins are independent packages.
-
-Package-specific events are added via **TypeScript declaration merging**. Each owning package ships a `src/events.ts` that augments the interface and is side-effect-imported from its `index.ts`:
-
-```ts
-// packages/<pkg>/src/events.ts
-import '@openplayerjs/core';
-
-declare module '@openplayerjs/core' {
-  interface PlayerEventPayloadMap {
-    'my:event': MyPayload;
-  }
-}
-```
-
-```ts
-// packages/<pkg>/src/index.ts
-import './events'; // registers the augmentation in the published types
-```
-
-Because `PlayerEventPayloadMap` is an `interface` (the one sanctioned exception to the `type`-over-`interface` rule — a `type` alias cannot be augmented), any consumer that imports the package gets its events typed on `core.on(...)` / `core.emit(...)`. Canonical example: [packages/ads/src/events.ts](packages/ads/src/events.ts). (The HLS engine currently augments nothing — it drives the player through standard core events only.)
-
-**To add an event:** core/kernel event → edit `packages/core/src/core/events.ts`. Package event → edit that package's `src/events.ts` augmentation (never core).
-
-Event naming conventions:
-
-- `cmd:*` — commands from player to engine (`cmd:play`, `cmd:pause`, `cmd:seek`, `cmd:startLoad`) — **core**
-- HTML5-native names without prefix — playback events bridged from DOM (`playing`, `pause`, `ended`, `loadedmetadata`) — **core**
-- `source:set` / `player:interacted` — source/interaction — **core**
-- `ads:*` — ad lifecycle events on the **shared EventBus** (all 20 events; `core.on('ads:X', cb)` works for any delivery mode) — **`@openplayerjs/ads`** (augmentation)
-
-### Iframe engine pattern
-
-For non-native engines (YouTube, etc.):
-
-1. Implement `IframeMediaAdapter` for the third-party API
-2. Wrap in `IframeMediaSurface` (internal EventBus-backed)
-3. Call `bindSurfaceEvents(surface, ctx.events)` + `bindCommands(ctx)`
-4. Call `ctx.setSurface(surface)` to swap active surface
-5. Call `surface.mount(ctx.container)` to inject the iframe
-6. In `detach()`: unbind → destroy surface → `ctx.resetSurface()`
-
-### Surface architecture
-
-- `HtmlMediaSurface` — wraps native `HTMLMediaElement` (default)
-- `IframeMediaSurface` — wraps an `IframeMediaAdapter`; polling-based state sync
-- `ctx.setSurface()` / `ctx.resetSurface()` — swap between surfaces
-- `MediaSurface` interface has: `currentTime`, `duration`, `volume`, `muted`, `playbackRate` (all read/write)
-
-### Overlay manager
-
-Accessed via `getOverlayManager(core)`. Highest-priority active overlay wins. Used by ads to display countdown/skip UI.
-
-### State manager
-
-```ts
-const state = new StateManager<PlaybackState>('idle');
-state.current; // current state string
-state.transition('playing');
-```
-
-States: `idle → loading → ready → playing ↔ paused`, also `waiting`, `seeking`, `ended`, `error`.
-
----
-
-## Cross-Package Import Rules
-
-All packages import `@openplayerjs/core` by package name — **never** by relative path.
-
-```ts
-// CORRECT (any non-core package)
-import { BaseMediaEngine, EventBus } from '@openplayerjs/core';
-
-// WRONG
-import { BaseMediaEngine } from '../../core/src/engines/base';
-```
-
-Path aliases are configured in `tsconfig.base.json` (for IDE/build) and `jest.config.cjs` (for tests).
-
----
-
-## Testing
-
-### Setup & environment
-
-- All tests run in `jsdom` (declared per-file: `/** @jest-environment jsdom */`)
-- `__tests__/setup/mediaMocks.ts` is loaded via `setupFilesAfterEnv` — provides `play()`, `pause()`, `load()`, `canPlayType()` mocks and media property getters/setters for all tests
-- Test runner: **Jest** + **ts-jest**
-
-### File naming conventions
-
-| Suffix                                          | Purpose                                       |
-| ----------------------------------------------- | --------------------------------------------- |
-| `*.test.ts`                                     | Happy-path and main feature coverage          |
-| `*.branches.test.ts`                            | Edge cases, error paths, conditional branches |
-| Feature-named: `player.autoplay.unmute.test.ts` | Specific behavior/scenario                    |
-
-### Test file locations
-
-Tests live in `packages/*/__tests__/` — not in a root `__tests__/` (only setup files are there).
-
-### Standard test structure
-
-```ts
-/** @jest-environment jsdom */
-
-describe('Feature name', () => {
-  // ── shared factory ────────────────────────────────────────────────────────
-  function makeCore() {
-    const v = document.createElement('video');
-    v.src = 'https://example.com/video.mp4';
-    document.body.appendChild(v);
-    return new Core(v, { plugins: [] });
-  }
-
-  beforeEach(() => {
-    // reset DOM state if needed
-    document.body.innerHTML = '';
-  });
-
-  test('description of expected behaviour', () => {
-    // Arrange
-    const p = makeCore();
-
-    // Act
-    p.events.emit('playing');
-
-    // Assert
-    expect(p.state.current).toBe('playing');
-  });
-});
-```
-
-### Core test conventions
-
-- Use a local `makeCore()` factory function — never rely on module-level state
-- For Core: pass `{ plugins: [] }` explicitly to avoid loading unintended engines
-- Simulate readiness: `p.events.emit('loadedmetadata')` to resolve `whenReady()`
-- Mock `play` / `pause` on Core when testing UI controls to make tests synchronous:
-  ```ts
-  p.play = jest.fn(async () => {
-    p.events.emit('playing');
-  }) as unknown as Core['play'];
-  p.pause = jest.fn(() => {
-    p.emit('cmd:pause');
-    p.events.emit('pause');
-  }) as unknown as Core['pause'];
-  ```
-
-### Timer-dependent tests
-
-Use `jest.useFakeTimers()` at the top of the describe block. Advance with `jest.advanceTimersByTime(ms)`.
-
-### Non-null helper pattern
-
-```ts
-function nn<T>(v: T | null | undefined): T {
-  expect(v).toBeTruthy();
-  return v as T;
-}
-```
-
-Use when querying DOM elements that must exist.
-
-### Mocking media properties
-
-```ts
-Object.defineProperty(p.media, 'paused', { value: false, configurable: true });
-```
-
-Use `configurable: true` so the property can be re-defined in later tests.
-
-### Mocking external libraries (ads)
-
-External packages `@dailymotion/vast-client` and `@dailymotion/vmap` are mapped to mocks in `packages/ads/__tests__/mocks/` via `jest.config.cjs moduleNameMapper`. The mock files export `jest.fn()` instances shared between tests and the mapper.
-
-### Mocking adapters (YouTube/iframe)
-
-Implement the interface (`IframeMediaAdapter`, etc.) with stub methods:
-
-```ts
-class StubAdapter implements IframeMediaAdapter {
-  private listeners = new Map<string, Function>();
-  on<E extends keyof IframeMediaAdapterEvents>(evt: E, cb: IframeMediaAdapterEvents[E]) {
-    this.listeners.set(evt as string, cb as Function);
-  }
-  emit<E extends keyof IframeMediaAdapterEvents>(evt: E, ...args: unknown[]) {
-    this.listeners.get(evt as string)?.(...args);
-  }
-  // ... other methods as jest.fn()
-}
-```
-
-### Coverage thresholds
-
-85% branches / functions / lines / statements globally. YouTube package is excluded from coverage collection. `umd.ts` and `index.ts` barrel files are also excluded.
-
-### Coverage gaps (as of Jun 2026)
-
-- `packages/youtube/` — excluded from thresholds; only basic engine lifecycle tested
-- `packages/ads/src/strategies/csai.ts` — weakest area (~74% branches); uncovered paths include SIMID, OMID, and HLS-engine-for-ad-video paths which require external dependencies and full browser contexts not available in jsdom
-- Async race conditions in surface swapping (Core.load with concurrent attach/detach)
-
----
-
-## Build & Tooling
-
-### Build sequence
-
-```sh
-pnpm run build        # clean → build:types → turbo build:bundles build:css
-pnpm run build:types  # tsc -b tsconfig.references.json (generates .d.ts)
-```
-
-### Output formats
-
-Each package produces:
-
-- `dist/index.js` — ESM (for bundlers)
-- `dist/openplayer*.js` + minified — UMD (CDN / browser globals)
-- `dist/types/` — TypeScript declarations
-
-### Rollup externals
-
-`@openplayerjs/core` is **external** to all consumer packages. It must not be bundled into `hls`, `ads`, `player`, or `youtube` builds.
-
-### Path resolution
-
-- **IDE / build**: `tsconfig.base.json` `paths` map `@openplayerjs/*` → `packages/*/src/index.ts`
-- **Jest**: `moduleNameMapper` in `jest.config.cjs` maps the same aliases
-- **Rollup**: `workspaceAlias()` plugin in `rollup.config.mjs` resolves them during bundle
-
-### Linting
-
-```sh
-pnpm run lint         # ESLint (flat config) + stylelint for CSS
-```
-
-Key enforced rules: `consistent-type-imports`, `consistent-type-definitions: type`, `import/no-cycle` (max depth 10), `no-unused-vars`.
-
----
-
-## Ads Plugin Architecture
-
-### Ad source modes (`adSourcesMode`)
-
-`AdsPluginConfig.adSourcesMode` controls how multiple ad sources are handled per break:
-
-- `'waterfall'` (default) — single `AdsBreakConfig` with a `sources: AdsSource[]` array. `startBreak()` tries each source in order and stops on first success. Failed tries do **not** emit `cmd:play` between attempts (`suppressResumeOnError`).
-- `'playlist'` — one `AdsBreakConfig` per source; the interceptor loop plays them sequentially.
-- Single source — same as before (no `sources` array).
-
-`playedBreaks.add(id)` is always called after `startBreak()` regardless of success, preventing infinite retry.
-
-### `resumeContent` default
-
-`resumeAfter = (this.cfg.resumeContent !== false) && meta.kind !== 'postroll'`
-
-`resumeContent` is **opt-out** (`!== false`), not opt-in. Using `=== true` means unset config defaults to `false` and content never resumes.
-
-### `preload="none"` VMAP deferral
-
-VMAP fetch starts synchronously at the top of the first `cmd:play` handler (not in `rebuildSchedule()`). This ensures `vmapPending=true` is captured before the eager-pause check runs.
-
-### `source:set` handler
-
-Calls `clearSession()` and also resets: `active=false`, `contentMedia=undefined`, overlay hidden, releases playback lease, deactivates `overlayManager`, clears `vmapLoadPromise`/`vmapPending`/`pendingVmapSrc`. This prevents stuck `active=true` state after source switches.
-
----
-
-## Key Behavioral Decisions
-
-### `cmd:play` fires synchronously before `await`
-
-`player.play()` emits `cmd:play` BEFORE any `await`, preserving the browser's user-gesture activation context (critical for Safari autoplay). Engines must call `media.play()` in the `cmd:play` handler immediately.
-
-### `resumeContent` defaults to `true` (opt-out)
-
-In AdsPlugin, `resumeContent !== false` — not `resumeContent === true`. Without this, unset config defaults to `false` and content never resumes after ads.
-
-### `preload="none"` VMAP deferral
-
-When `preload="none"`, VMAP fetch starts synchronously at the top of the first play handler (not in `rebuildSchedule()`). This ensures `vmapPending=true` is set before the eager-pause check runs.
-
-### HLS readiness signal
-
-`MANIFEST_PARSED` emits `loadedmetadata` on EventBus (resolves `whenReady()` fast). The DOM `loadedmetadata` still fires later via `bindMediaEvents` but is a no-op for the readiness promise.
-
-### UMD plugin registration
-
-Plugins must be passed to `CorePlayer` constructor before `maybeAutoLoad()` is called. UMD bundles register themselves on `window.OpenPlayerPlugins`; `Player.init()` reads that before constructing CorePlayer.
+Sanctioned `as any` (one aliased opaque type per library, single eslint-disable at the alias):
+untyped external outputs (`@dailymotion/vast-client`, VMAP, OMID, SIMID) and experimental
+browser APIs absent from TS lib. Pattern: `export type VastParsed = any;` in `ads/src/types.ts`.
+
+**R5 — `cmd:play` must stay synchronous.**
+`Core.play()` emits `cmd:play` **before any `await`** to preserve the browser user-gesture
+context (Safari autoplay). Engines call `media.play()` immediately in the handler. The ads
+preroll interceptor must not `await` anything before acquiring the lease/pausing content.
+Never insert an `await`, microtask, or setTimeout upstream of these emits.
+
+**R6 — `resumeContent !== false`, never `=== true`.**
+It is opt-out. `=== true` makes unset config default to false → content never resumes after
+ads. Tested in `ads.test.ts`; the same opt-out pattern applies to other `Xxx !== false` checks
+you'll find — do not "simplify" them.
+
+**R7 — Cross-package imports use the package name.**
+`import { EventBus } from '@openplayerjs/core'` — never `../../core/src/…`. Aliases are wired
+in `tsconfig.base.json` (IDE/build), `jest.config.cjs` (tests), and `rollup.config.mjs`
+(bundles). `@openplayerjs/core` is **external** in every consumer package's Rollup build; if
+core code appears inside `dist/` of hls/ads/player/youtube, the build is wrong.
+
+**R8 — Do not touch `tsconfig.base.json` target/lib.**
+`target: "ES2022"` + `lib: [... "ESNext.Disposable"]` is load-bearing: ES2020 breaks
+`build:types` (`[Symbol.dispose]` in dispose.ts) and bloats dist ~16% via downleveled class
+fields. `erasableSyntaxOnly` cannot be enabled (parameter properties are used throughout).
+
+**R9 — All cleanup goes through disposables.**
+Plugins: register every subscription via `ctx.dispose` / `ctx.on()` / `ctx.listen()`.
+Controls: `this.dispose.addEventListener(...)` or `this.listen(...)` — never bare
+`addEventListener`. Engines: `bindSurfaceEvents`/`bindCommands` in `attach()`, matching
+unbinds in `detach()`. A missed unbind is a leak that only shows up in multi-source tests.
+
+**R10 — Keep `this` bound when forwarding third-party events.**
+Extracting `const on = this.adapter.on` unbinds `this` and fails at runtime under mocks. Cast
+the _object_, then call the method on it: `(this.adapter as unknown as Api).on(evt, handler)`.
+
+**R11 — Versioning is the orchestrator's job.**
+Never hand-edit `version` fields, tags, or `CHANGELOG.md`. `scripts/orchestrate-release.cjs`
+owns them (core changed → all packages lockstep at one version; else per-package). Bump type
+comes from conventional commits (`feat`→minor, `fix`→patch, `BREAKING CHANGE`→major).
+
+**R12 — Commits must satisfy commitlint or the hook rejects them.**
+Format: `type(scope): subject`. Types: feat|fix|perf|refactor|chore|docs|test|build|ci|revert.
+Scope is **required**, from: core|player|hls|ads|youtube|deps|ci|release|docs|repo|changelog
+(multi-package: `feat(core,player): …`). Header ≤150 chars, subject not Start/Pascal/UPPER case.
+
+**R13 — Core stays dependency-free and package-agnostic.**
+No runtime deps in `packages/core/package.json`, ever. No imports from sibling packages. No
+knowledge of ads/hls/ui concepts in core source or types.
+
+**R14 — Don't invent guard rails or validation.**
+`StateManager` transitions are unguarded by design; don't add checks. Validate only at system
+boundaries (user config, network XML, third-party APIs). Defensive try/catch is for plugin
+isolation (a broken plugin must not crash the player), not for impossible states.
+
+**R15 — UI strings come from `defaultLabels`.**
+No hard-coded English in `packages/player/src/controls/`. Add the key to `defaultLabels` in
+`configuration.ts`; callers override via `config.labels`.
+
+**R16 — Generated/derived files are never edited by hand.**
+`dist/`, `dist/types/`, `coverage/`, `CHANGELOG.md`, `pnpm-lock.yaml` (except via pnpm
+commands), `playwright-report/`, `test-results/`.
+
+## 4. Conventions
+
+- **Files** kebab-case (`event-bus.ts`) · **classes** PascalCase · **methods/props** camelCase ·
+  **constants** UPPER_SNAKE_CASE · explicit access modifiers, `readonly` when never reassigned.
+- `type` over `interface` (ESLint-enforced; sole exception R2). `import type` for type-only
+  imports (enforced). `unknown` over `any`. `import/no-cycle` is an error.
+- Event names: `cmd:*` = player→engine commands; unprefixed HTML5-native names = bridged DOM
+  playback events; `ads:*` etc. = package events via augmentation (R1). Never emit or subscribe
+  with an untyped string.
+- Payload conventions (ads): break descriptor `{ id, kind }` under a `break` property;
+  `ads:quartile` is `{ breakId, quartile: 25|50|75|100 }`; SSAI uses `kind: 'ssai'`.
+- Comments state constraints the code can't show. No narration, no "why my change is correct."
+  Match surrounding density.
+
+## 5. Testing (the spec lives here — read tests before changing behavior)
+
+- Jest + ts-jest, jsdom. Every test file starts with `/** @jest-environment jsdom */`.
+- Location: `packages/<pkg>/__tests__/`. Root `__tests__/setup/mediaMocks.ts` is auto-loaded
+  and provides `play()/pause()/load()/canPlayType()` and media property accessors.
+- Naming: `*.test.ts` happy path · `*.branches.test.ts` edge/error paths ·
+  feature-named files (`player.autoplay.unmute.test.ts`) for specific scenarios.
+- Structure: local `makeCore()` factory per describe; `new Core(v, { plugins: [] })` explicitly;
+  no module-level state; `document.body.innerHTML = ''` in beforeEach when the DOM is touched.
+- Readiness: `p.events.emit('loadedmetadata')` resolves `whenReady()`. Make play/pause
+  synchronous in UI tests by stubbing them (`p.play = jest.fn(async () => p.events.emit('playing')) as unknown as Core['play']`).
+- Timers: `jest.useFakeTimers()` + `advanceTimersByTime` — never real waits.
+- Ads externals: **never** import `@dailymotion/vast-client`/`vmap` in tests; jest
+  `moduleNameMapper` routes them to `packages/ads/__tests__/mocks/`. VAST fixtures:
+  `packages/ads/__tests__/fixtures/ads/*.xml`.
+- Coverage: 85% branches/functions/lines/statements globally. Excluded: youtube package,
+  `umd.ts`, `index.ts` barrels. Known weak spot: `ads/src/strategies/csai.ts` (~74% branches —
+  SIMID/OMID paths need real browsers).
+- `nn<T>()` helper for must-exist DOM queries; `configurable: true` on every defineProperty.
+
+## 6. Quality gates — checkable, per deliverable
+
+**G0 — every code change, no exceptions.** All of:
+
+1. `pnpm run type-check` exits 0.
+2. `pnpm run lint` — 0 errors AND no new warnings (baseline is 0 `no-explicit-any` warnings
+   in both src and tests; keep it there).
+3. `pnpm run build` succeeds (catches .d.ts and rollup breakage type-check misses).
+4. `pnpm run test` passes and global coverage stays ≥85% on all four metrics.
+5. Diff contains no edits to generated files (R16) and no new `as any`/`@ts-ignore`/
+   `eslint-disable` outside the sanctioned patterns (R4).
+
+**G1 — bug fix.** G0, plus: a test that fails on the pre-fix code and passes after (name it
+after the behavior, put it in the owning package's `__tests__/`); if the bug came from a
+GitHub issue, reference it in the commit (`fixes #NNN`); if the fix encodes a new behavioral
+rule, add it to the owning package's CLAUDE.md.
+
+**G2 — feature.** G0, plus: public types exported from the package's `index.ts`; new events
+follow R1 including the side-effect import; config options documented in the package README;
+package CLAUDE.md updated if the feature adds a rule or invariant; user-visible player
+behavior gets an `examples/*.html` page and an `e2e/*.spec.ts` when it can only be proven in
+a real browser; happy-path AND branch tests.
+
+**G3 — refactor.** G0, plus: zero behavior change (no test assertions modified — if a test
+must change, it's not a refactor, say so); public API surface identical
+(`git diff dist/types/` after build shows no changes, or the change is explicitly approved);
+event emissions removed only per R3.
+
+**G4 — new control (player).** G2, plus: extends `BaseControl` with `id`, `placement`,
+`build()`; factory `createXxxControl()` exported; registered in `getControlFactory()` in
+`src/umd.ts`; all strings via `defaultLabels` (R15); listeners via disposables (R9);
+a11y label via `setA11yLabel()`.
+
+**G5 — new engine.** G2, plus: extends `BaseMediaEngine` with all abstract members;
+`priority` chosen consciously (HTML5=0, HLS=50, YouTube=100); `attach()`/`detach()` symmetric
+per R9; iframe engines follow the surface swap sequence in `packages/core/CLAUDE.md`.
+
+**G6 — release readiness** (when asked to prepare a release): working tree clean; G0 green;
+`pnpm run preflight` passes; `pnpm run test:e2e` passes; `pnpm run release:dry-run` output
+reviewed and version/lockstep behavior matches intent. Actually publishing is E1 below.
+
+## 7. Uncertainty and escalation
+
+**Resolution order when you don't know how something behaves** (exhaust these before asking):
+
+1. Tests in the owning package's `__tests__/` — they are the executable spec.
+2. The owning package's `CLAUDE.md`, then `ARCHITECTURE.md`.
+3. `git log --follow -p <file>` — recent history explains most surprises; PR-squash bodies
+   are detailed in this repo.
+4. Any additional sources listed in `.claude/CLAUDE.local.md`, if present.
+
+**Proceed without asking (E0):** reversible changes within the stated task scope; adding
+tests; updating docs alongside code; fixing lint/type errors your change introduced;
+choosing between two internal implementations when one clearly matches existing patterns
+(note the choice in your summary).
+
+**Stop and ask first (E1):** running `pnpm run release*` (anything non-dry-run) or `npm
+publish`; `git push` of any kind; deleting files you did not create in the session; changing
+a public API signature, an event name, or an event payload shape (all are breaking for
+downstream consumers); adding or upgrading any dependency; editing shared config
+(`tsconfig*`, `rollup*`, `jest.config.cjs`, `eslint.config.cjs`, `turbo.json`,
+`commitlint.config.cjs`); editing any repository outside this one when the task didn't
+mention it; weakening a coverage threshold or excluding a file from coverage; anything
+under R16.
+
+**Ambiguity rule:** if two readings of the task lead to different public behavior, ask. If
+they lead to the same public behavior, pick the one consistent with the closest existing
+pattern and state the assumption in your summary. Never invent product behavior (new events,
+new config options, new defaults) that the task didn't request.
+
+**Failure honesty:** report failing gates verbatim with the command output. Never mark a
+deliverable done with a failing test, a skipped gate, or an unverified claim.
+
+## 8. Behavioral decisions ledger (why the code looks "wrong" but isn't)
+
+- `cmd:play` synchronous before `await` — Safari user-gesture (R5).
+- `resumeContent !== false` — opt-out semantics (R6).
+- VMAP with `preload="none"` fetches synchronously at the top of the first `cmd:play`
+  handler, not in `rebuildSchedule()` — so `vmapPending=true` beats the eager-pause check.
+- `playedBreaks.add(id)` after `startBreak()` regardless of success — prevents infinite retry.
+- Waterfall ads (`adSourcesMode:'waterfall'`) suppress `cmd:play` between failed source
+  attempts (`suppressResumeOnError`).
+- `source:set` in ads resets the full session (active flag, contentMedia, overlay, lease,
+  vmap state) — partial resets leave the plugin stuck `active=true`.
+- HLS `MANIFEST_PARSED` emits `loadedmetadata` on the EventBus so `whenReady()` resolves
+  before the DOM event; duration/live flow through native `durationchange`, not custom events.
+- ID3 timed metadata uses the native TextTrack API (`enableID3MetadataCues` +
+  `enableDateRangeMetadataCues` + `renderTextTracksNatively`, contract locked by
+  `engines.test.ts`) — do not add a metadata event.
+- UMD plugins must reach the `CorePlayer` constructor before `maybeAutoLoad()`; `Player.init()`
+  reads `window.OpenPlayerPlugins` first.
+- Fullscreen `'f'` uses `keyTarget` (wrapper), not `e.target`; focus-out handlers use
+  `queueMicrotask`, not `setTimeout`.


### PR DESCRIPTION
## What

Rewrites the root `CLAUDE.md` from a general development guide into an **operating manual** aimed at letting any model work in this repo at a high bar, and adds three project skills under `.claude/skills/`.

### `CLAUDE.md`
- **16 rules, each tied to the concrete mistake it prevents** — e.g. never put package events in core's `PlayerEventPayloadMap` (use per-package `events.ts` declaration merging), keep `cmd:play` synchronous for the Safari user-gesture window, `resumeContent !== false` (opt-out, not `=== true`), no new `as any` with the typed alternative for each situation, and don't touch `tsconfig.base.json` target/lib.
- **Checkable per-deliverable quality gates (G0–G6)** — type-check, lint (no new warnings), build, tests + 85% coverage, plus specific extra criteria for bug fixes, features, refactors, new controls, and new engines.
- **Explicit escalation policy** — a resolution order to exhaust before asking, an E0 "proceed without asking" list, and an E1 "stop and ask first" list (releases, pushes, public API/event/payload changes, dependency and shared-config edits).
- A "looks wrong but isn't" behavioral-decisions ledger, and a pointer to the per-package `CLAUDE.md` files as the authoritative detail layer.

### New skills (`.claude/skills/`)
- **`add-event`** — kernel-vs-package event routing, declaration merging, payload conventions, and the safe rename/removal procedure (grep tests before deleting any emit).
- **`preship`** — a tiered verification gauntlet through the release dry-run, with generated-file and escape-hatch hygiene checks.
- **`write-tests`** — this repo's test conventions (`makeCore()` factories, fake timers, media-property mocking, ads mocks) and the typed-access recipes that avoid `as any`.

### `.gitignore`
- Un-ignores `.claude/skills/` so the skills are tracked, while keeping `.claude/settings.json`, `settings.local.json`, and `CLAUDE.local.md` private.

## Why

The previous `CLAUDE.md` described conventions but didn't encode the failure modes specific to this codebase or give checkable done-criteria. This version turns hard-won lessons (event-hierarchy boundaries, ads timing invariants, the `as any` removal patterns) into rules a less-capable model can follow, and moves procedural how-tos into on-demand skills.

## Reviewer notes

- Docs/tooling only — no source, build, or test-runtime changes. CI behavior is unaffected.
- The three per-package `CLAUDE.md` files are unchanged; the root file now explicitly defers to them.
