### PR TITLE
ci(repo): bump Pages workflow actions to current majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # The branch root IS the site. Copy it into _site, excluding VCS internals
       # so the Git directory is never uploaded as a Pages artifact.
@@ -42,13 +42,13 @@ jobs:
           rsync -a --exclude='.git' --exclude='_site' ./ _site/
 
       - name: Configure Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Updates the GitHub Pages workflow actions to their current stable majors, still SHA-pinned with matching version comments.

| action | before | after |
|---|---|---|
| actions/checkout | v4.3.1 | **v7.0.0** |
| actions/configure-pages | v5.0.0 | **v6.0.0** |
| actions/upload-pages-artifact | v3.0.1 | **v5.0.0** |
| actions/deploy-pages | v4.0.5 | **v5.0.0** |

**Why:** the original pins targeted stale majors, which trips outdated-action warnings. These are the current releases; `upload-pages-artifact` and `deploy-pages` move to v5 as a matched pair (new artifact backend). Base is `gh-pages` where the workflow lives.