### PR TITLE
fix(repo): replace dead example video, de-flake live progress assertion and recover vmap breaks

### DIFF
--- a/e2e/live.spec.ts
+++ b/e2e/live.spec.ts
@@ -29,7 +29,9 @@ test.describe('Live — HLS live stream', () => {
   test('renders player wrapper and controls', async ({ page }) => {
     await expect(page.locator(sel.wrapper)).toBeVisible();
     await expect(page.locator(sel.play)).toBeVisible();
-    await expect(page.locator(sel.progress)).toBeVisible();
+    // The progress bar is built, but it hides itself as soon as `isLive` is
+    // detected — asserting visibility here races the manifest parse.
+    await expect(page.locator(sel.progress)).toBeAttached();
     await expect(page.locator(sel.settings)).toBeVisible();
   });
 

--- a/examples/ads.html
+++ b/examples/ads.html
@@ -12,10 +12,7 @@
 <body>
   <div id="wrap">
     <video id="player" class="op-player__media" controls playsinline muted>
-      <source
-        src="https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4"
-        type="video/mp4"
-      />
+      <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4" />
     </video>
   </div>
 

--- a/examples/captions.html
+++ b/examples/captions.html
@@ -19,17 +19,8 @@
 <body>
   <div id="wrap">
     <video id="player" class="op-player__media" controls playsinline muted>
-      <source
-        src="https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4"
-        type="video/mp4"
-      />
-      <track
-        kind="subtitles"
-        src="./captions/captions-en.vtt"
-        srclang="en"
-        label="English"
-        default
-      />
+      <source src="https://vjs.zencdn.net/v/oceans.mp4" type="video/mp4" />
+      <track kind="subtitles" src="./captions/captions-en.vtt" srclang="en" label="English" default />
     </video>
   </div>
 <script type="importmap">

--- a/packages/ads/__tests__/ads.vmapManualParse.test.ts
+++ b/packages/ads/__tests__/ads.vmapManualParse.test.ts
@@ -2,6 +2,7 @@
 
 import type { PluginContext } from '@openplayerjs/core';
 import { EventBus } from '@openplayerjs/core';
+import VMAP from '@dailymotion/vmap';
 import { AdsPlugin } from '../src/ads';
 
 /** AdsPlugin with `@internal` getters narrowed to non-undefined for test access. */
@@ -10,9 +11,17 @@ type AdsPluginInternals = AdsPlugin & {
   pendingPercentBreaks: NonNullable<AdsPlugin['pendingPercentBreaks']>;
 };
 
+/** VMAP mock knobs: `__breaks` is what the library "parses", `__throw` makes it choke. */
+const vmapMock = VMAP as unknown as { __breaks: unknown[]; __throw: unknown };
+
 const globalWithFetch = globalThis as unknown as { fetch: unknown };
 
 describe('AdsPlugin VMAP DOM fallback parser', () => {
+  beforeEach(() => {
+    vmapMock.__breaks = [];
+    vmapMock.__throw = null;
+  });
+
   test('parses namespaced VMAP XML directly when VMAP lib returns no breaks', async () => {
     const video = document.createElement('video');
     document.body.appendChild(video);
@@ -59,5 +68,42 @@ describe('AdsPlugin VMAP DOM fallback parser', () => {
     Object.defineProperty(video, 'duration', { configurable: true, value: 200 });
     const due = plugin.getDueMidrollBreaks(101);
     expect(due.some((b) => b.id?.includes('mid'))).toBe(true);
+  });
+
+  test('falls back to XML parsing when the VMAP library throws', async () => {
+    vmapMock.__throw = new Error('VMAP library exploded');
+
+    const video = document.createElement('video');
+    document.body.appendChild(video);
+
+    const ctx = {
+      core: { media: video, muted: false, volume: 1 },
+      events: new EventBus(),
+      state: { current: 'ready' },
+      leases: { acquire: () => true, release: () => undefined, owner: () => undefined },
+    } as unknown as PluginContext;
+
+    const plugin = new AdsPlugin({
+      interceptPlayForPreroll: false,
+      allowNativeControls: true,
+    }) as unknown as AdsPluginInternals;
+    plugin.setup(ctx);
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <VMAP xmlns="http://www.iab.net/videosuite/vmap" version="1.0">
+        <AdBreak breakType="linear" timeOffset="start" breakId="pre">
+          <AdSource><AdTagURI><![CDATA[https://example.com/pre.xml]]></AdTagURI></AdSource>
+        </AdBreak>
+      </VMAP>`;
+
+    globalWithFetch.fetch = jest.fn(async () => ({ ok: true, text: async () => xml }));
+
+    await plugin.loadVmapAndMerge([], 'https://example.com/vmap.xml');
+
+    // The library never produced a break, so the DOM parser must supply it.
+    const pre = plugin.resolvedBreaks.find((b) => b.at === 'preroll');
+    expect(pre?.source?.src).toBe('https://example.com/pre.xml');
+    // A library crash is recovered, not surfaced as a failed load.
+    expect(plugin.vmapPending).toBe(false);
   });
 });

--- a/packages/ads/__tests__/mocks/vmap.ts
+++ b/packages/ads/__tests__/mocks/vmap.ts
@@ -1,7 +1,10 @@
 export default class VMAP {
   static __breaks: unknown[] = [];
+  /** When set, the constructor throws it — simulates the library choking on malformed VMAP XML. */
+  static __throw: unknown = null;
   adBreaks: unknown[];
   constructor() {
+    if (VMAP.__throw) throw VMAP.__throw;
     this.adBreaks = VMAP.__breaks;
   }
 }

--- a/packages/ads/src/schedule.ts
+++ b/packages/ads/src/schedule.ts
@@ -85,6 +85,9 @@ type PendingPercentBreak = {
   source: AdsSource;
 };
 
+/** Ad break as produced by `@dailymotion/vmap`; the library ships no types, so fields stay `unknown`. */
+type VmapAdBreak = { breakType?: unknown; timeOffset?: unknown; breakId?: unknown; adSource?: unknown };
+
 /** A namespace-aware DOM query root. `ParentNode` alone lacks `getElementsByTagName*` in the TS lib. */
 type DOMQuerier = ParentNode & {
   getElementsByTagNameNS?(ns: string, name: string): HTMLCollectionOf<Element>;
@@ -280,10 +283,19 @@ export class AdScheduler {
           });
 
       const xmlDoc = new DOMParser().parseFromString(xmlText, 'text/xml');
-      const vmap = new VMAP(xmlDoc);
       const vmapBreaks: AdsBreakConfig[] = [];
-      const breaks = vmap.adBreaks || [];
       const prevPendingCount = this.pendingPercentBreaks.length;
+
+      let breaks: VmapAdBreak[] = [];
+      try {
+        const vmap = new VMAP(xmlDoc);
+        breaks = Array.isArray(vmap?.adBreaks) ? (vmap.adBreaks as VmapAdBreak[]) : [];
+      } catch (err) {
+        this.warn('VMAP library parse failed, falling back to XML parser', err);
+        this.parseVmapFallback(xmlDoc, vmapBreaks, prevPendingCount);
+        this.resolvedBreaks = [...existing, ...vmapBreaks];
+        return;
+      }
 
       const rawAdBreakCount = (() => {
         try {


### PR DESCRIPTION
`new VMAP(xmlDoc)` throws on malformed VMAP XML, which aborted the whole load and discarded breaks the DOM fallback parser could still recover. Wrap the construction and route a crash through `parseVmapFallback`, the same path already used when the library under-counts breaks. Parsing third-party network XML is a system boundary, so the guard is in scope.
    
The accompanying test previously installed a file-level `jest.mock('@dailymotion/vmap')` whose constructor always threw. That bypassed the shared mock wired through `moduleNameMapper` and silently changed what the pre-existing test exercised: with every construction throwing, the library success path (including the original "returns no breaks -> fall back" branch) went completely uncovered, dropping schedule.ts from 46.45% to 40.78% statements and 30.74% to 27.03% branches while both tests still passed.
    
Add a `__throw` knob to the shared mock instead and scope it per test via `beforeEach`, so one test covers the no-breaks path and the other the throw path.
    
The example content source 404s at the origin: https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4
    
In the browser it surfaces as MediaError code 4 / NotSupportedError, so `currentTime` never leaves 0. That is the deterministic cause of the two failing ads e2e tests ("content video plays after preroll ends" and "content currentTime advances after all preroll ads are done"), which is why they failed every attempt including both CI retries rather than flaking. Point ads.html and captions.html at a live 46s clip instead.
    
Separately, "Live -> renders player wrapper and controls" asserted the progress bar is visible, but progress.ts correctly sets aria-hidden once `core.isLive` flips true, so the assertion races the manifest parse. Assert the control is attached instead, which holds in both states.