### PR TITLE
fix(release): verify github token before publishing and credit real handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,26 @@ _August 3, 2026_
 
 #### Bug Fixes
 
-- **[ads]** recover vmap breaks when the parser library throws (919ec28) @Rafael Miranda
-- **[repo]** replace dead example video and de-flake live progress assertion (919ec28) @Rafael Miranda
+- **[ads]** recover vmap breaks when the parser library throws (919ec28) @rafa8626
+- **[repo]** replace dead example video and de-flake live progress assertion (919ec28) @rafa8626
 
 ### General
 
 #### Features
 
-- **[release]** publish a GitHub Release per version from the orchestrator ([#603](https://github.com/openplayerjs/openplayerjs/pull/603)) @Rafael Miranda
+- **[release]** publish a GitHub Release per version from the orchestrator ([#603](https://github.com/openplayerjs/openplayerjs/pull/603)) @rafa8626
   - lockstep / same-version cycles -> a single umbrella release tagged
   - diverged cycles -> one release per package on its existing
 
 #### Bug Fixes
 
-- **[deps]** Added exclusion for package to accept vulnerability (c72393f) @Rafael Miranda
-- **[deps]** Fixed vulnerabilities: GHSA-mh99-v99m-4gvg, GHSA-2p49-hgcm-8545 and GHSA-v2hh-gcrm-f6hx (13819d8) @Rafael Miranda
-- **[deps]** repair broken pnpm-lock.yaml js-yaml entry (cdb81ce) @Rafael Miranda
+- **[deps]** Added exclusion for package to accept vulnerability (c72393f) @rafa8626
+- **[deps]** Fixed vulnerabilities: GHSA-mh99-v99m-4gvg, GHSA-2p49-hgcm-8545 and GHSA-v2hh-gcrm-f6hx (13819d8) @rafa8626
+- **[deps]** repair broken pnpm-lock.yaml js-yaml entry (cdb81ce) @rafa8626
 
 #### Documentation
 
-- **[repo]** rewrite CLAUDE.md as operating manual and add AI skills ([#602](https://github.com/openplayerjs/openplayerjs/pull/602)) @Rafael Miranda
+- **[repo]** rewrite CLAUDE.md as operating manual and add AI skills ([#602](https://github.com/openplayerjs/openplayerjs/pull/602)) @rafa8626
 
 #### Chores
 
@@ -76,7 +76,7 @@ _July 1, 2026_
 
 #### Refactoring
 
-- **[ads]** centralise constants and split SIMID transport into SimidRpcChannel (c6b238c) @Rafael Miranda
+- **[ads]** centralise constants and split SIMID transport into SimidRpcChannel (c6b238c) @rafa8626
   - Add `constants.ts` with the named thresholds/limits (skip near-end, seek delta,
   - Split the 751-line simid.ts into three files by extracting the module's own code:
   - `simid-protocol.ts` — SIMID 1.2 message constants + wire types.
@@ -93,11 +93,11 @@ _July 1, 2026_
 
 #### Bug Fixes
 
-- **[repo]** Removed comments and flag from JSON file (c6b238c) @Rafael Miranda
+- **[repo]** Removed comments and flag from JSON file (c6b238c) @rafa8626
 
 #### Refactoring
 
-- **[repo]** strict typing, package event hierarchy, and tooling modernization (c6b238c) @Rafael Miranda
+- **[repo]** strict typing, package event hierarchy, and tooling modernization (c6b238c) @rafa8626
   - Remove every `@typescript-eslint/no-explicit-any` in source and test files;
   - `PlayerEventPayloadMap` is now an augmentable `interface` declaring ONLY
   - Moved all `ads:*` events into `packages/ads/src/events.ts`; unified the ad
@@ -106,7 +106,7 @@ _July 1, 2026_
 
 #### Chores
 
-- **[ci]** make Coveralls report-only so small coverage decreases don't block merges (c6b238c) @Rafael Miranda
+- **[ci]** make Coveralls report-only so small coverage decreases don't block merges (c6b238c) @rafa8626
 - **[deps]** update dependency rollup to v4.62.2 ([#596](https://github.com/openplayerjs/openplayerjs/pull/596)) @renovate[bot]
 - **[deps]** update dependency @playwright/test to v1.61.1 ([#595](https://github.com/openplayerjs/openplayerjs/pull/595)) @renovate[bot]
 - **[deps]** update node.js to v26.3.1 ([#590](https://github.com/openplayerjs/openplayerjs/pull/590)) @renovate[bot]
@@ -124,11 +124,11 @@ _June 21, 2026_
 
 #### Bug Fixes
 
-- **[core]** set isLive=true immediately when config.duration is Infinity (3f5e34d) @Rafael Miranda
+- **[core]** set isLive=true immediately when config.duration is Infinity (3f5e34d) @rafa8626
 
 #### Reverts
 
-- **[core]** remove constructor isLive shortcut for config.duration=Infinity (3f5e34d) @Rafael Miranda
+- **[core]** remove constructor isLive shortcut for config.duration=Infinity (3f5e34d) @rafa8626
 
 ### `@openplayerjs/player@3.5.6`
 
@@ -158,7 +158,7 @@ _June 21, 2026_
 
 #### Features
 
-- **[core,player]** sourceFallback on by default, isLive from Infinity, showLiveCurrentTime config (3f5e34d) @Rafael Miranda
+- **[core,player]** sourceFallback on by default, isLive from Infinity, showLiveCurrentTime config (3f5e34d) @rafa8626
   - sourceFallback defaults to true so multiple <source> tags fall back
   - Core.load() and the src setter reset isLive to false on each new source;
   - PlayerUIConfig gains showLiveCurrentTime (default false); when true the
@@ -185,7 +185,7 @@ _June 19, 2026_
 
 #### Bug Fixes
 
-- **[ads]** normalize ads.error payload to include message string and error object ([#586](https://github.com/openplayerjs/openplayerjs/pull/586)) @Rafael Miranda
+- **[ads]** normalize ads.error payload to include message string and error object ([#586](https://github.com/openplayerjs/openplayerjs/pull/586)) @rafa8626
 
 ### `@openplayerjs/youtube@3.5.5`
 
@@ -197,7 +197,7 @@ _June 19, 2026_
 
 #### Bug Fixes
 
-- **[core,ads,hls,player]** fix zero-seek bug, v() caching, and expand meaningful test coverage ([#587](https://github.com/openplayerjs/openplayerjs/pull/587)) @Rafael Miranda
+- **[core,ads,hls,player]** fix zero-seek bug, v() caching, and expand meaningful test coverage ([#587](https://github.com/openplayerjs/openplayerjs/pull/587)) @rafa8626
   - core: fix startTime=0 silently skipped by falsy check (if (this._currentTime) → !== 0)
   - ads/csai: cache v() getter in cmd:play/setVolume/setMuted handlers to prevent stale-ref bugs
   - tests: add startTime=0/30 seek tests, shouldForceMute (autoplay/non-autoplay) paths,
@@ -205,7 +205,7 @@ _June 19, 2026_
 
 #### Documentation
 
-- **[repo]** add local dev, release workflow, ads architecture, and event extension guidance ([#585](https://github.com/openplayerjs/openplayerjs/pull/585)) @Rafael Miranda
+- **[repo]** add local dev, release workflow, ads architecture, and event extension guidance ([#585](https://github.com/openplayerjs/openplayerjs/pull/585)) @rafa8626
   - Add Local Development section with all pnpm scripts (build, watch, test, e2e, lint, type-check)
   - Add Releases section documenting the lockstep vs. independent release rules and all release:* commands
   - Add Ads Plugin Architecture section covering adSourcesMode waterfall/playlist, resumeContent opt-out, VMAP deferral, and source:set reset behavior
@@ -214,7 +214,7 @@ _June 19, 2026_
 
 #### Chores
 
-- **[deps]** fix audit vulnerabilities via pnpm overrides (3d11205) @Rafael Miranda
+- **[deps]** fix audit vulnerabilities via pnpm overrides (3d11205) @rafa8626
 
 ## [3.5.4](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/core%403.5.4) (2026-06-19)
 
@@ -224,7 +224,7 @@ _June 19, 2026_
 
 #### Features
 
-- **[core]** add source fallback with source:fallback event (9c160a8) @Rafael Miranda
+- **[core]** add source fallback with source:fallback event (9c160a8) @rafa8626
 
 ### `@openplayerjs/player@3.5.4`
 
@@ -256,15 +256,15 @@ _June 19, 2026_
 
 - **[deps]** Upgraded Node version to 26.3.0 (400e370) @renovate[bot]
 - **[deps]** Updated lock (9d1e6b3) @renovate[bot]
-- **[repo]** Fix lockstep version skipping packages ahead of core (ca9bb1b) @Rafael Miranda
+- **[repo]** Fix lockstep version skipping packages ahead of core (ca9bb1b) @rafa8626
 
 #### Documentation
 
-- **[docs]** fix CDN links to use scoped packages with @latest (2ec8dca) @Rafael Miranda
+- **[docs]** fix CDN links to use scoped packages with @latest (2ec8dca) @rafa8626
 
 #### Chores
 
-- **[repo]** suppress Node deprecation warnings in test and e2e scripts (4a17a5e) @Rafael Miranda
+- **[repo]** suppress Node deprecation warnings in test and e2e scripts (4a17a5e) @rafa8626
 - **[deps]** update dependency @types/node to v24.13.1 ([#583](https://github.com/openplayerjs/openplayerjs/pull/583)) @renovate[bot]
 - **[deps]** update turbo monorepo to v2.9.17 ([#582](https://github.com/openplayerjs/openplayerjs/pull/582)) @renovate[bot]
 - **[deps]** pin dependencies (400e370) @renovate[bot]
@@ -278,7 +278,7 @@ _June 19, 2026_
 
 #### Tests
 
-- **[repo]** add source-fallback e2e spec with full player UI (7f4915a) @Rafael Miranda
+- **[repo]** add source-fallback e2e spec with full player UI (7f4915a) @rafa8626
 
 ## [3.5.3](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/player%403.5.3) (2026-05-27)
 
@@ -288,18 +288,18 @@ _May 26, 2026_
 
 #### Features
 
-- **[repo]** Added new GitHub Action to publish packages without access tokens (4511cd1) @Rafael Miranda
+- **[repo]** Added new GitHub Action to publish packages without access tokens (4511cd1) @rafa8626
 
 #### Bug Fixes
 
-- **[player]** Set flag to reset current time and dispatched event in play button when setting source; fixes #567 (9f42e64) @Rafael Miranda
-- **[repo]** Fixed release scripts to write CHANGELOG file correctly on each release, even per package (96b6ada) @Rafael Miranda
+- **[player]** Set flag to reset current time and dispatched event in play button when setting source; fixes #567 (9f42e64) @rafa8626
+- **[repo]** Fixed release scripts to write CHANGELOG file correctly on each release, even per package (96b6ada) @rafa8626
 
 ### General
 
 #### Bug Fixes
 
-- **[repo]** Fix lockstep version skipping packages ahead of core (ca9bb1b) @Rafael Miranda
+- **[repo]** Fix lockstep version skipping packages ahead of core (ca9bb1b) @rafa8626
 
 ## [3.4.4](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/core%403.4.4) (2026-05-27)
 
@@ -309,7 +309,7 @@ _May 26, 2026_
 
 #### Bug Fixes
 
-- **[core]** Added conditional to avoid loading source when preload is `none`; fixes #562 (48ed8b1) @Rafael Miranda
+- **[core]** Added conditional to avoid loading source when preload is `none`; fixes #562 (48ed8b1) @rafa8626
 
 ### `@openplayerjs/hls@3.4.4`
 
@@ -333,18 +333,18 @@ _May 26, 2026_
 
 #### Features
 
-- **[repo]** Added new GitHub Action to publish packages without access tokens (4511cd1) @Rafael Miranda
+- **[repo]** Added new GitHub Action to publish packages without access tokens (4511cd1) @rafa8626
 
 #### Bug Fixes
 
-- **[repo]** Fixed release scripts to write CHANGELOG file correctly on each release, even per package (96b6ada) @Rafael Miranda
-- **[player]** Set flag to reset current time and dispatched event in play button when setting source; fixes #567 (9f42e64) @Rafael Miranda
-- **[player]** Fixed script to add CHANGELOG when releasing a version; added missing command to update stylesheet in player before release (45932b4) @Rafael Miranda
-- **[repo]** Fixed orchestrator script to avoid overriding versions (c899f29) @Rafael Miranda
+- **[repo]** Fixed release scripts to write CHANGELOG file correctly on each release, even per package (96b6ada) @rafa8626
+- **[player]** Set flag to reset current time and dispatched event in play button when setting source; fixes #567 (9f42e64) @rafa8626
+- **[player]** Fixed script to add CHANGELOG when releasing a version; added missing command to update stylesheet in player before release (45932b4) @rafa8626
+- **[repo]** Fixed orchestrator script to avoid overriding versions (c899f29) @rafa8626
 
 #### Chores
 
-- **[deps]** Upgraded Node to v26.2.0 (87bdf72) @Rafael Miranda
+- **[deps]** Upgraded Node to v26.2.0 (87bdf72) @rafa8626
 - **[deps]** update eslint ([#566](https://github.com/openplayerjs/openplayerjs/pull/566)) @renovate[bot]
 - **[deps]** update postcss ([#565](https://github.com/openplayerjs/openplayerjs/pull/565)) @renovate[bot]
 - **[deps]** update dependency rollup to v4.60.4 ([#564](https://github.com/openplayerjs/openplayerjs/pull/564)) @renovate[bot]
@@ -368,13 +368,13 @@ _May 17, 2026_
 
 #### Bug Fixes
 
-- **[player]** Fixed script to add CHANGELOG when releasing a version; added missing command to update stylesheet in player before release (45932b4) @Rafael Miranda
+- **[player]** Fixed script to add CHANGELOG when releasing a version; added missing command to update stylesheet in player before release (45932b4) @rafa8626
 
 ### General
 
 #### Bug Fixes
 
-- **[repo]** Fixed orchestrator script to avoid overriding versions (c899f29) @Rafael Miranda
+- **[repo]** Fixed orchestrator script to avoid overriding versions (c899f29) @rafa8626
 
 ## [3.5.1](https://github.com/openplayerjs/openplayerjs/compare/@openplayerjs/player@3.5.0...@openplayerjs/player@3.5.1) (2026-05-18)
 
@@ -392,15 +392,15 @@ _May 17, 2026_
 
 #### Bug Fixes
 
-- **[player]** Fixed failing unit test; switched DOM by CSS in time delimiter to show it (3063aec) @Rafael Miranda
-- **[player]** Fixed issue when selecting speed not being checked; added missing config to set speeds manually (8ae756c) @Rafael Miranda
-- **[docs]** Added missing configuration to update CHANGELOG if individual package is released (b04d5f7) @Rafael Miranda
+- **[player]** Fixed failing unit test; switched DOM by CSS in time delimiter to show it (3063aec) @rafa8626
+- **[player]** Fixed issue when selecting speed not being checked; added missing config to set speeds manually (8ae756c) @rafa8626
+- **[docs]** Added missing configuration to update CHANGELOG if individual package is released (b04d5f7) @rafa8626
 
 ### General
 
 #### Bug Fixes
 
-- **[repo]** Fixed orchestrator script to avoid overriding versions (c899f29) @Rafael Miranda
+- **[repo]** Fixed orchestrator script to avoid overriding versions (c899f29) @rafa8626
 
 ## [3.5.0](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/player%403.5.0) (2026-05-17)
 
@@ -410,12 +410,12 @@ _May 17, 2026_
 
 #### Bug Fixes
 
-- **[player]** Added missing `title` attributes for all controls to show tooltips (d30b35e) @Rafael Miranda
-- **[player]** Added missing export in UMD to allow for indexed controls (5b2b23b) @Rafael Miranda
-- **[docs]** Unified UMD documentation for better readability and added missing capabilities documentation (474a3be) @Rafael Miranda
-- **[docs]** Added new migration for UMD player; fixed inconsistencies (00780fb) @Rafael Miranda
-- **[docs]** Fixed UMD names; added more documentation for `registerControl` and `addControl` (c4610ca) @Rafael Miranda
-- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @Rafael Miranda
+- **[player]** Added missing `title` attributes for all controls to show tooltips (d30b35e) @rafa8626
+- **[player]** Added missing export in UMD to allow for indexed controls (5b2b23b) @rafa8626
+- **[docs]** Unified UMD documentation for better readability and added missing capabilities documentation (474a3be) @rafa8626
+- **[docs]** Added new migration for UMD player; fixed inconsistencies (00780fb) @rafa8626
+- **[docs]** Fixed UMD names; added more documentation for `registerControl` and `addControl` (c4610ca) @rafa8626
+- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @rafa8626
 
 ---
 
@@ -469,20 +469,20 @@ _May 17, 2026_
 
 #### Features
 
-- **[repo]** Added new configuration flags for Renovate bot (d61b3d2) @Rafael Miranda
+- **[repo]** Added new configuration flags for Renovate bot (d61b3d2) @rafa8626
 
 #### Bug Fixes
 
-- **[docs]** Added missing configuration to update CHANGELOG if individual package is released (b04d5f7) @Rafael Miranda
-- **[deps]** Added overrides to remove high severity vulnerabilities (ab50e69) @Rafael Miranda
-- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @Rafael Miranda
-- **[repo]** Fixed MIME type in captions example (bffa4fe) @Rafael Miranda
-- **[docs]** Fixed CHANGELOG entry for better readability and removed typo for UMD files across project (55a8691) @Rafael Miranda
-- **[docs]** Update legacy v2 docs link to point to GitHub (de08983) @Rafael Miranda
-- **[docs]** Updated TOC for migration document to remove 404 pages; fixes #538 (33e3c61) @Rafael Miranda
-- **[docs]** Set link for labels to remove 404 page. Fixes #530 (0151389) @Rafael Miranda
-- **[docs]** Fixed typos in CHANGELOG (939bb3a) @Rafael Miranda
-- **[repo]** Updated videos for examples and increased grace period to render ads in tests (e08f4fc) @Rafael Miranda
+- **[docs]** Added missing configuration to update CHANGELOG if individual package is released (b04d5f7) @rafa8626
+- **[deps]** Added overrides to remove high severity vulnerabilities (ab50e69) @rafa8626
+- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @rafa8626
+- **[repo]** Fixed MIME type in captions example (bffa4fe) @rafa8626
+- **[docs]** Fixed CHANGELOG entry for better readability and removed typo for UMD files across project (55a8691) @rafa8626
+- **[docs]** Update legacy v2 docs link to point to GitHub (de08983) @rafa8626
+- **[docs]** Updated TOC for migration document to remove 404 pages; fixes #538 (33e3c61) @rafa8626
+- **[docs]** Set link for labels to remove 404 page. Fixes #530 (0151389) @rafa8626
+- **[docs]** Fixed typos in CHANGELOG (939bb3a) @rafa8626
+- **[repo]** Updated videos for examples and increased grace period to render ads in tests (e08f4fc) @rafa8626
 
 #### Chores
 
@@ -504,12 +504,12 @@ _May 17, 2026_
 - **[deps]** update github/codeql-action digest to 95e58e9 ([#526](https://github.com/openplayerjs/openplayerjs/pull/526)) @renovate[bot]
 - **[deps]** update actions/setup-node digest to 48b55a0 ([#528](https://github.com/openplayerjs/openplayerjs/pull/528)) @renovate[bot]
 - **[deps]** update dependency hls.js to v1.6.16 ([#529](https://github.com/openplayerjs/openplayerjs/pull/529)) @renovate[bot]
-- **[deps]** Upgraded basic-ftp package to remove vulnerability (354630e) @Rafael Miranda
+- **[deps]** Upgraded basic-ftp package to remove vulnerability (354630e) @rafa8626
 - **[deps]** update actions/upload-artifact digest to 043fb46 ([#522](https://github.com/openplayerjs/openplayerjs/pull/522)) @renovate[bot]
 - **[deps]** update dependency undici to v7.25.0 ([#525](https://github.com/openplayerjs/openplayerjs/pull/525)) @renovate[bot]
 - **[deps]** update dependency defu to v6.1.7 ([#523](https://github.com/openplayerjs/openplayerjs/pull/523)) @renovate[bot]
 - **[deps]** update dependency prettier to v3.8.2 ([#524](https://github.com/openplayerjs/openplayerjs/pull/524)) @renovate[bot]
-- **[repo]** Removed unnecessary overrides (a6aa8f2) @Rafael Miranda
+- **[repo]** Removed unnecessary overrides (a6aa8f2) @rafa8626
 
 ## [3.5.0](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/player%403.5.0) (2026-05-16)
 
@@ -519,15 +519,15 @@ _May 16, 2026_
 
 #### Bug Fixes
 
-- **[player]** Added missing export in UMD to allow for indexed controls (5b2b23b) @Rafael Miranda
-- **[player]** Added missing `title` attributes for all controls to show tooltips (d30b35e) @Rafael Miranda
+- **[player]** Added missing export in UMD to allow for indexed controls (5b2b23b) @rafa8626
+- **[player]** Added missing `title` attributes for all controls to show tooltips (d30b35e) @rafa8626
 
 #### Documentation
 
-- **[docs]** Unified UMD documentation for better readability and added missing capabilities documentation (474a3be) @Rafael Miranda
-- **[docs]** Added new migration for UMD player; fixed inconsistencies (00780fb) @Rafael Miranda
-- **[docs]** Fixed UMD names; added more documentation for `registerControl` and `addControl` (c4610ca) @Rafael Miranda
-- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @Rafael Miranda
+- **[docs]** Unified UMD documentation for better readability and added missing capabilities documentation (474a3be) @rafa8626
+- **[docs]** Added new migration for UMD player; fixed inconsistencies (00780fb) @rafa8626
+- **[docs]** Fixed UMD names; added more documentation for `registerControl` and `addControl` (c4610ca) @rafa8626
+- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @rafa8626
 
 ---
 
@@ -539,29 +539,29 @@ _May 16, 2026_
 
 #### Bug Fixes
 
-- **[docs]** Unified UMD documentation for better readability and added missing capabilities documentation (474a3be) @Rafael Miranda
-- **[player]** Added missing export in UMD to allow for indexed controls (5b2b23b) @Rafael Miranda
-- **[docs]** Added new migration for UMD player; fixed inconsistencies (00780fb) @Rafael Miranda
-- **[docs]** Fixed UMD names; added more documentation for `registerControl` and `addControl` (c4610ca) @Rafael Miranda
-- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @Rafael Miranda
-- **[player]** Added missing `title` attributes for all controls to show tooltips (d30b35e) @Rafael Miranda
+- **[docs]** Unified UMD documentation for better readability and added missing capabilities documentation (474a3be) @rafa8626
+- **[player]** Added missing export in UMD to allow for indexed controls (5b2b23b) @rafa8626
+- **[docs]** Added new migration for UMD player; fixed inconsistencies (00780fb) @rafa8626
+- **[docs]** Fixed UMD names; added more documentation for `registerControl` and `addControl` (c4610ca) @rafa8626
+- **[docs]** Removed inconsistencies, and enhanced documentation related to `player` UMD wrapper (51566a7) @rafa8626
+- **[player]** Added missing `title` attributes for all controls to show tooltips (d30b35e) @rafa8626
 
 ### General
 
 #### Features
 
-- **[repo]** Added new configuration flags for Renovate bot (d61b3d2) @Rafael Miranda
+- **[repo]** Added new configuration flags for Renovate bot (d61b3d2) @rafa8626
 
 #### Bug Fixes
 
-- **[deps]** Added overrides to remove high severity vulnerabilities (ab50e69) @Rafael Miranda
-- **[repo]** Fixed MIME type in captions example (bffa4fe) @Rafael Miranda
-- **[docs]** Fixed CHANGELOG entry for better readability and removed typo for UMD files across project (55a8691) @Rafael Miranda
-- **[docs]** Update legacy v2 docs link to point to GitHub (de08983) @Rafael Miranda
-- **[docs]** Updated TOC for migration document to remove 404 pages; fixes #538 (33e3c61) @Rafael Miranda
-- **[docs]** Set link for labels to remove 404 page. Fixes #530 (0151389) @Rafael Miranda
-- **[docs]** Fixed typos in CHANGELOG (939bb3a) @Rafael Miranda
-- **[repo]** Updated videos for examples and increased grace period to render ads in tests (e08f4fc) @Rafael Miranda
+- **[deps]** Added overrides to remove high severity vulnerabilities (ab50e69) @rafa8626
+- **[repo]** Fixed MIME type in captions example (bffa4fe) @rafa8626
+- **[docs]** Fixed CHANGELOG entry for better readability and removed typo for UMD files across project (55a8691) @rafa8626
+- **[docs]** Update legacy v2 docs link to point to GitHub (de08983) @rafa8626
+- **[docs]** Updated TOC for migration document to remove 404 pages; fixes #538 (33e3c61) @rafa8626
+- **[docs]** Set link for labels to remove 404 page. Fixes #530 (0151389) @rafa8626
+- **[docs]** Fixed typos in CHANGELOG (939bb3a) @rafa8626
+- **[repo]** Updated videos for examples and increased grace period to render ads in tests (e08f4fc) @rafa8626
 
 #### Chores
 
@@ -583,12 +583,12 @@ _May 16, 2026_
 - **[deps]** update github/codeql-action digest to 95e58e9 ([#526](https://github.com/openplayerjs/openplayerjs/pull/526)) @renovate[bot]
 - **[deps]** update actions/setup-node digest to 48b55a0 ([#528](https://github.com/openplayerjs/openplayerjs/pull/528)) @renovate[bot]
 - **[deps]** update dependency hls.js to v1.6.16 ([#529](https://github.com/openplayerjs/openplayerjs/pull/529)) @renovate[bot]
-- **[deps]** Upgraded basic-ftp package to remove vulnerability (354630e) @Rafael Miranda
+- **[deps]** Upgraded basic-ftp package to remove vulnerability (354630e) @rafa8626
 - **[deps]** update actions/upload-artifact digest to 043fb46 ([#522](https://github.com/openplayerjs/openplayerjs/pull/522)) @renovate[bot]
 - **[deps]** update dependency undici to v7.25.0 ([#525](https://github.com/openplayerjs/openplayerjs/pull/525)) @renovate[bot]
 - **[deps]** update dependency defu to v6.1.7 ([#523](https://github.com/openplayerjs/openplayerjs/pull/523)) @renovate[bot]
 - **[deps]** update dependency prettier to v3.8.2 ([#524](https://github.com/openplayerjs/openplayerjs/pull/524)) @renovate[bot]
-- **[repo]** Removed unnecessary overrides (a6aa8f2) @Rafael Miranda
+- **[repo]** Removed unnecessary overrides (a6aa8f2) @rafa8626
 
 ## [3.4.2](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/core%403.4.2) (2026-04-07)
 
@@ -598,7 +598,7 @@ _April 7, 2026_
 
 #### Bug Fixes
 
-- **[core]** align detach() signature with Core's calling convention and fix tsconfig deprecation (8db3f28) @Rafael Miranda
+- **[core]** align detach() signature with Core's calling convention and fix tsconfig deprecation (8db3f28) @rafa8626
   - BaseMediaEngine.detach() now accepts optional ctx param to match how
   - tsconfig.json: remove deprecated module/moduleResolution overrides;
   - tsconfig.jest.json: add ignoreDeprecations:"5.0" to suppress the
@@ -614,7 +614,7 @@ _April 7, 2026_
 
 #### Chores
 
-- **[hls]** Suggested improvements in HLS package (8c4a2a4) @Rafael Miranda
+- **[hls]** Suggested improvements in HLS package (8c4a2a4) @rafa8626
   - Created variable for magic number used to check for errors, renamed private variable and consolidated play behavior across engine to improve readability
   - Renamed function in unit tests for better readability
 
@@ -628,38 +628,38 @@ _April 7, 2026_
 
 #### Bug Fixes
 
-- **[youtube]** Renamed constants and expanded comments for better readability (c9614a4) @Rafael Miranda
-- **[youtube]** Replaced pseudo type to `video` since `x-video` is considered deprecated (c6ea561) @Rafael Miranda
+- **[youtube]** Renamed constants and expanded comments for better readability (c9614a4) @rafa8626
+- **[youtube]** Replaced pseudo type to `video` since `x-video` is considered deprecated (c6ea561) @rafa8626
 
 #### Chores
 
-- **[youtube]** Added constant to replace magic number (e749f16) @Rafael Miranda
-- **[youtube]** Renamed variables/methods for better readability (6ba7a74) @Rafael Miranda
+- **[youtube]** Added constant to replace magic number (e749f16) @rafa8626
+- **[youtube]** Renamed variables/methods for better readability (6ba7a74) @rafa8626
 
 ### General
 
 #### Bug Fixes
 
-- **[repo]** Moved closed captions to proper position per VAST 4.1 specs (38ace49) @Rafael Miranda
-- **[repo]** Fixed typo in YT example and changed source to use YT ID (43d75ce) @Rafael Miranda
+- **[repo]** Moved closed captions to proper position per VAST 4.1 specs (38ace49) @rafa8626
+- **[repo]** Fixed typo in YT example and changed source to use YT ID (43d75ce) @rafa8626
 
 #### Chores
 
-- **[repo]** Removed unused import from example (1d3eb96) @Rafael Miranda
-- **[repo]** Added new script to share ad unit among examples (4e7941c) @Rafael Miranda
-- **[repo]** Fixed inconsistent spacing and added plugin in example file (28c28c6) @Rafael Miranda
-- **[repo]** Fixed script to avoid issues related to new lines (8df4459) @Rafael Miranda
-- **[repo]** Removed duplicate HLS instantiation and added missing plugin (bd8ae54) @Rafael Miranda
-- **[repo]** Added initial e2e tests using Playwright (74373c7) @Rafael Miranda
-- **[repo]** release scripts improvements (c0537a7) @Rafael Miranda
+- **[repo]** Removed unused import from example (1d3eb96) @rafa8626
+- **[repo]** Added new script to share ad unit among examples (4e7941c) @rafa8626
+- **[repo]** Fixed inconsistent spacing and added plugin in example file (28c28c6) @rafa8626
+- **[repo]** Fixed script to avoid issues related to new lines (8df4459) @rafa8626
+- **[repo]** Removed duplicate HLS instantiation and added missing plugin (bd8ae54) @rafa8626
+- **[repo]** Added initial e2e tests using Playwright (74373c7) @rafa8626
+- **[repo]** release scripts improvements (c0537a7) @rafa8626
   - Fixed orchestrator script by cleaning up regex and fixing logic to handle different package versions and avoid duplicate entries per package
   - Fixed split changelog script by changing slightly regex to avoid matching across line boundaries and using trimStart() method to avoid removing meaningful indentation from nested list items or code blocks
   - Fixed entries in CHANGELOG after changes
-- **[docs]** Fixed issues in MIGRATION document adding missing links and correcting typos (8d0210f) @Rafael Miranda
+- **[docs]** Fixed issues in MIGRATION document adding missing links and correcting typos (8d0210f) @rafa8626
 - **[deps]** update dependency @types/node to v24.12.2 ([#518](https://github.com/openplayerjs/openplayerjs/pull/518)) @renovate[bot]
 - **[deps]** update dependency cssnano to v7.1.4 ([#519](https://github.com/openplayerjs/openplayerjs/pull/519)) @renovate[bot]
 - **[deps]** update dependency ts-jest to v29.4.9 ([#520](https://github.com/openplayerjs/openplayerjs/pull/520)) @renovate[bot]
-- **[deps]** Fixed new vulnerability CVE-2026-35209 (aaeed73) @Rafael Miranda
+- **[deps]** Fixed new vulnerability CVE-2026-35209 (aaeed73) @rafa8626
 
 ## [3.4.1](https://github.com/openplayerjs/openplayerjs/releases/tag/@openplayerjs/core%403.4.1) (2026-04-02)
 
@@ -687,7 +687,7 @@ _April 2, 2026_
 
 #### Bug Fixes
 
-- **[repo]** Changed Renovate strategy to pin dependencies and pinned all packages versions (e635c12) @Rafael Miranda
+- **[repo]** Changed Renovate strategy to pin dependencies and pinned all packages versions (e635c12) @rafa8626
 - **[deps]** update dependency @dailymotion/vast-client to ^6.4.4 ([#516](https://github.com/openplayerjs/openplayerjs/pull/516)) @renovate[bot]
 
 ### `@openplayerjs/youtube@3.4.1`
@@ -700,19 +700,19 @@ _April 2, 2026_
 
 #### Bug Fixes
 
-- **[repo]** minor refactor and coverage increase (3750fa6) @Rafael Miranda
+- **[repo]** minor refactor and coverage increase (3750fa6) @rafa8626
   - Added new tsconfig to solve TS issues in unit tests
   - Split logic from core into 2 new utilities to split responsibilities
   - Fixed issue when checking cues for SSAI strategy using streaming engines
   - Added more unit tests based on changes
-- **[deps]** Fixed high severity vulnerability related to code injection (b2c0f2f) @Rafael Miranda
-- **[repo]** Modified orchestrator script to consider squash merge commits; updated CHANGELOG (a0d1ca6) @Rafael Miranda
+- **[deps]** Fixed high severity vulnerability related to code injection (b2c0f2f) @rafa8626
+- **[repo]** Modified orchestrator script to consider squash merge commits; updated CHANGELOG (a0d1ca6) @rafa8626
 
 #### Chores
 
-- **[repo]** Added new workflow to scan for package vulnerabilities (b822b73) @Rafael Miranda
-- **[deps]** Fixed high severity vulnerability (ed16a03) @Rafael Miranda
-- **[docs]** Added new badge for OpenSSF Best Practices (1f2ab90) @Rafael Miranda
+- **[repo]** Added new workflow to scan for package vulnerabilities (b822b73) @rafa8626
+- **[deps]** Fixed high severity vulnerability (ed16a03) @rafa8626
+- **[docs]** Added new badge for OpenSSF Best Practices (1f2ab90) @rafa8626
 - **[deps]** update dependency rollup to ^4.60.1 ([#515](https://github.com/openplayerjs/openplayerjs/pull/515)) @renovate[bot]
 - **[deps]** update node.js ([#513](https://github.com/openplayerjs/openplayerjs/pull/513)) @renovate[bot]
 - **[deps]** update eslint to ^8.57.2 ([#512](https://github.com/openplayerjs/openplayerjs/pull/512)) @renovate[bot]
@@ -729,13 +729,13 @@ _March 28, 2026_
 
 #### Chores
 
-- **[docs]** Fixed wrong packages names in documentation (168724d) @Rafael Miranda
+- **[docs]** Fixed wrong packages names in documentation (168724d) @rafa8626
 
 ### `@openplayerjs/player@3.4.0`
 
 #### Features
 
-- **[player]** WCAG 2.2 enhancements for controls ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[player]** WCAG 2.2 enhancements for controls ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Added wrapper and factory to generate area for screen readers to announce events
   - Integrated announcer factory and aria-live attributes in all controls that have user interactions
   - Added missing label from configurations for Settings control
@@ -744,25 +744,25 @@ _March 28, 2026_
 
 #### Bug Fixes
 
-- **[player]** Expanded unit test coverage in player package ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[player]** Expanded unit test coverage in player package ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
 
 ### `@openplayerjs/hls@3.4.0`
 
 #### Features
 
-- **[hls]** Enhanced support for metadata tracks in HLS ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[hls]** Enhanced support for metadata tracks in HLS ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Added new HLS.js configuration to support ID3 frames and EXT-X-DATERANGE as metadata TextTrack cues so consumers can detect splice points using `cuechange` event
   - Added new method to generate a separate instance of HLS.js intended to be used for ads that render m3u8 files without interfering with main instance
 
 #### Bug Fixes
 
-- **[hls]** Marked edge cases to avoid decreasing coverage ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[hls]** Marked edge cases to avoid decreasing coverage ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
 
 ### `@openplayerjs/ads@3.4.0`
 
 #### Features
 
-- **[ads]** Support for SSAI and hybrid approaches, refactor for CSAI ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[ads]** Support for SSAI and hybrid approaches, refactor for CSAI ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Refactor ads configuration to support new server-side ads integration (SSAI) and hybrid (client-side ads integration, or CSAI, triggered by SCTE-35 OUT cues) strategies, leaving `debug` and `sources` untouched for backward compatibility
   - Created new area to contain new SSAI and hybrid strategies for better separation of concerns
   - Moved Ads client-side logic into a new strategy class to keep code readable and have better separation of concerns
@@ -771,13 +771,13 @@ _March 28, 2026_
 
 #### Bug Fixes
 
-- **[ads]** Added new labels configuration for ads and expanded coverage ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
-- **[ads]** Added missing `await` to playBreakFromVast call ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
-- **[ads]** Removal of deprecated method and SIMID warning ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[ads]** Added new labels configuration for ads and expanded coverage ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
+- **[ads]** Added missing `await` to playBreakFromVast call ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
+- **[ads]** Removal of deprecated method and SIMID warning ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Removed deprecated method after refactor for CSAI strategy
   - Removed warning for SIMID iframe related to target origin
   - Updated unit tests after fixes
-- **[ads]** Marked edge cases to avoid decreasing coverage ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[ads]** Marked edge cases to avoid decreasing coverage ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
 
 ### `@openplayerjs/youtube@3.4.0`
 
@@ -789,23 +789,23 @@ _March 28, 2026_
 
 #### Bug Fixes
 
-- **[repo]** Replaced extension for release commands to match new extension in scripts (6017cd8) @Rafael Miranda
-- **[docs]** Updated CHANGELOG with proper entries from v3.3.0 and added scope for contributing guidelines (cf6f5dd) @Rafael Miranda
-- **[release]** CHANGELOG fixes ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[repo]** Replaced extension for release commands to match new extension in scripts (6017cd8) @rafa8626
+- **[docs]** Updated CHANGELOG with proper entries from v3.3.0 and added scope for contributing guidelines (cf6f5dd) @rafa8626
+- **[release]** CHANGELOG fixes ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Modified script to add descriptions from commits, and consolidate it for improve CHANGELOG
   - Removed CHANGELOG per package to consolidate all in main one
   - Rewrote CHANGELOG to indicate changes according to new orchestrator changes
-- **[repo]** Fixed vulnerabilities and issues in unit tests ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[repo]** Fixed vulnerabilities and issues in unit tests ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
 
 #### Chores
 
-- **[deps]** Upgraded lock file (be8bce3) @Rafael Miranda
-- **[release]** Adjustments for release workflow ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[deps]** Upgraded lock file (be8bce3) @rafa8626
+- **[release]** Adjustments for release workflow ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Increased branch coverage to 85%
   - Added new commands to verify that release is ready and more in sync to what MUI does
   - Removed inline elements from each package's release-it config file to merge everything into main one
   - Minor formatting issues
-- **[repo]** File conversion to CommonJS ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @Rafael Miranda
+- **[repo]** File conversion to CommonJS ([#507](https://github.com/openplayerjs/openplayerjs/pull/507)) @rafa8626
   - Converted Rollup configuration files to `.cjs` to make them more portable
   - Converted scripts to `.cjs` to make them more portable
   - Updated scripts in all `package.json` files to adjust to these changes
@@ -820,7 +820,7 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- **[core]** iframe engine polling and ended-state fixes (3b7ccd8) @Rafael Miranda
+- **[core]** iframe engine polling and ended-state fixes (3b7ccd8) @rafa8626
   - Added equality guards in `applyVolume`, `applyDuration`, and `applyRate` to suppress no-op events during the 250 ms poll tick
   - Consolidated volume/muted reads into a single `applyVolume` call per tick instead of two
   - Suppressed `timeupdate` emission when iframe media is paused or ended
@@ -833,7 +833,7 @@ _March 24, 2026_
 
 #### Features
 
-- **[player]** WCAG 2.2 enhancements for controls (180a140) @Rafael Miranda
+- **[player]** WCAG 2.2 enhancements for controls (180a140) @rafa8626
   - Added wrapper and factory to generate a single shared ARIA live region for screen-reader announcements
   - Integrated announcer and `aria-live` attributes across all interactive controls
   - Added missing label from configurations for the Settings control
@@ -843,13 +843,13 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- **[player]** shared a11y announcer, event cleanup, and volume control loop fix (d2df296) @Rafael Miranda
+- **[player]** shared a11y announcer, event cleanup, and volume control loop fix (d2df296) @rafa8626
   - Refactored announcer to generate a single pair of ARIA live regions instead of one per control
   - Refactored event listeners to return their `off` callback so all are cleaned up on `destroy`
   - Removed unexpected re-entrancy loop in `VolumeControl.syncActiveMedia` caused by interactions between core, ads, and the control itself
   - Fixed `syncActiveMedia` to not write `el.volume` when muted (volume-change path vs. mute-click path)
   - Restored direct overlay-media sync for keyboard `ArrowUp` / `ArrowDown` / `M` handlers
-- **[player]** expanded unit test coverage in player package (990690a) @Rafael Miranda
+- **[player]** expanded unit test coverage in player package (990690a) @rafa8626
 
 ### `@openplayerjs/hls@3.3.0`
 
@@ -861,7 +861,7 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- **[ads]** added new labels configuration for ads and expanded coverage (0ded85c) @Rafael Miranda
+- **[ads]** added new labels configuration for ads and expanded coverage (0ded85c) @rafa8626
 - **[deps]** update dependency @dailymotion/vast-client to ^6.4.3 ([#497](https://github.com/openplayerjs/openplayerjs/pull/497)) @renovate[bot]
 
 ### `@openplayerjs/youtube@3.3.0`
@@ -874,19 +874,19 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- **[release]** CHANGELOG fixes and script improvements (ac09425) @Rafael Miranda
+- **[release]** CHANGELOG fixes and script improvements (ac09425) @rafa8626
   - Modified split-changelog script to include commit descriptions in generated notes
   - Removed per-package CHANGELOG files in favour of the consolidated root changelog
-- **[release]** added `changelog` as a valid scope (69891eb) @Rafael Miranda
+- **[release]** added `changelog` as a valid scope (69891eb) @rafa8626
 
 #### Chores
 
-- **[release]** adjustments for release workflow (2935ad8) @Rafael Miranda
+- **[release]** adjustments for release workflow (2935ad8) @rafa8626
   - Increased branch coverage to 85%
   - Added new commands to verify release readiness
   - Removed inline configuration from per-package `.release-it.cjs` files in favour of the root config
 - **[deps]** update dependency rollup to ^4.60.0 ([#505](https://github.com/openplayerjs/openplayerjs/pull/505)) @renovate[bot]
-- Fixed vulnerability (7facec4) @Rafael Miranda
+- Fixed vulnerability (7facec4) @rafa8626
 - **[deps]** update dependency rollup to ^4.59.1 ([#500](https://github.com/openplayerjs/openplayerjs/pull/500)) @renovate[bot]
 - **[deps]** update dependency turbo to ^2.8.20 ([#501](https://github.com/openplayerjs/openplayerjs/pull/501)) @renovate[bot]
 - **[deps]** update dependency undici to >=7.24.5 ([#502](https://github.com/openplayerjs/openplayerjs/pull/502)) @renovate[bot]
@@ -919,7 +919,7 @@ _March 24, 2026_
 
 #### Features
 
-- SIMID/OMID support ([#495](https://github.com/openplayerjs/openplayerjs/pull/495)) @Rafael Miranda
+- SIMID/OMID support ([#495](https://github.com/openplayerjs/openplayerjs/pull/495)) @rafa8626
   - Split ads file for better maintenance and separation of concerns
   - Generated new files to split responsibilities, including skeletons for SIMID and OMID formats
   - Added new HTML elements when parsing XML ads, removed after ad ends
@@ -972,7 +972,7 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- **[repo]** Updated orchestration file to skip versions if package is already at or above the target (c0bda19) @Rafael Miranda
+- **[repo]** Updated orchestration file to skip versions if package is already at or above the target (c0bda19) @rafa8626
 
 #### Chores
 
@@ -994,10 +994,10 @@ _March 24, 2026_
 - **[deps]** update dependency stylelint-order to v8 ([#473](https://github.com/openplayerjs/openplayerjs/pull/473)) @renovate[bot]
 - **[deps]** update dependency turbo to ^2.8.15 ([#475](https://github.com/openplayerjs/openplayerjs/pull/475)) @renovate[bot]
 - **[deps]** update pnpm to v10.32.1 ([#476](https://github.com/openplayerjs/openplayerjs/pull/476)) @renovate[bot]
-- Remove vulnerabilities after upgrades (4b9d158) @Rafael Miranda
-- Removed unnecessary overrides (924d755) @Rafael Miranda
+- Remove vulnerabilities after upgrades (4b9d158) @rafa8626
+- Removed unnecessary overrides (924d755) @rafa8626
 - **[deps]** pin dependencies ([#491](https://github.com/openplayerjs/openplayerjs/pull/491)) @renovate[bot]
-- Enhancements for release cycle (c5c0eff) @Rafael Miranda
+- Enhancements for release cycle (c5c0eff) @rafa8626
   - Fixed release-it hook to publish to NPM after git push has succeeded
   - Enhanced orchestrator script to generate release notes and append them to CHANGELOG
   - Refactor renovate configuration for better dependency strategy and scheduling
@@ -1010,7 +1010,7 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- publishing packages ([#472](https://github.com/openplayerjs/openplayerjs/pull/472)) @Rafael Miranda
+- publishing packages ([#472](https://github.com/openplayerjs/openplayerjs/pull/472)) @rafa8626
   - Disabled per-package `npm` publish to resolve peer-dependency version conflicts
   - Modified orchestration script to populate root CHANGELOG
   - Added v3.1.0 changes in root CHANGELOG
@@ -1043,8 +1043,8 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- Added missing flag on pre-commit hook invocation during release (7423955) @Rafael Miranda
-- Fixed version of YouTube package after incorrect tag (eb1e0a6) @Rafael Miranda
+- Added missing flag on pre-commit hook invocation during release (7423955) @rafa8626
+- Fixed version of YouTube package after incorrect tag (eb1e0a6) @rafa8626
 
 #### Chores
 
@@ -1060,7 +1060,7 @@ _March 24, 2026_
 
 #### Refactoring
 
-- surface layer, Renovate integration and ads fixes ([#458](https://github.com/openplayerjs/openplayerjs/pull/458)) @Rafael Miranda
+- surface layer, Renovate integration and ads fixes ([#458](https://github.com/openplayerjs/openplayerjs/pull/458)) @rafa8626
   - Added new surface layer (`HtmlMediaSurface`, `IframeMediaSurface`) in preparation for iframe-based engines (YouTube, etc.) with a unified approach across packages and controls
   - Added new captions layer in core package to support captions across different engines via `CaptionTrackProvider`
   - Added `BaseMediaEngine` lifecycle helpers: `bindSurfaceEvents`, `bindCommands`, `unbindSurfaceEvents`
@@ -1071,7 +1071,7 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- surface layer, Renovate integration and ads fixes ([#458](https://github.com/openplayerjs/openplayerjs/pull/458)) @Rafael Miranda
+- surface layer, Renovate integration and ads fixes ([#458](https://github.com/openplayerjs/openplayerjs/pull/458)) @rafa8626
   - Fixed multiple ad lifecycle issues following the surface-layer refactor
 
 ### `@openplayerjs/player@3.1.0`
@@ -1096,17 +1096,17 @@ _March 24, 2026_
 
 #### Bug Fixes
 
-- Removed release-it config flags in favor of release notes (bb8cd59) @Rafael Miranda
-- Added new commit types for releases (ec6c75f) @Rafael Miranda
-- Removing .npmrc not needed (ad5f8fe) @Rafael Miranda
-- Added fallback for NPM_TOKEN (7c74c62) @Rafael Miranda
-- Changed orchestration file to read .env from package root (6e39215) @Rafael Miranda
+- Removed release-it config flags in favor of release notes (bb8cd59) @rafa8626
+- Added new commit types for releases (ec6c75f) @rafa8626
+- Removing .npmrc not needed (ad5f8fe) @rafa8626
+- Added fallback for NPM_TOKEN (7c74c62) @rafa8626
+- Changed orchestration file to read .env from package root (6e39215) @rafa8626
 
 #### Chores
 
 - Configure Renovate ([#459](https://github.com/openplayerjs/openplayerjs/pull/459)) @renovate[bot]
-- Added permanent `.npmrc` to use `NPM_TOKEN` automatically (5afa092) @Rafael Miranda
-- Added YouTube package to the list of supported packages in orchestrator (eb1e0a6) @Rafael Miranda
+- Added permanent `.npmrc` to use `NPM_TOKEN` automatically (5afa092) @rafa8626
+- Added YouTube package to the list of supported packages in orchestrator (eb1e0a6) @rafa8626
 - **[deps]** update coverallsapp/github-action action to v2.3.6 ([#466](https://github.com/openplayerjs/openplayerjs/pull/466)) @renovate[bot]
 - **[deps]** update pnpm to v10.32.0 ([#467](https://github.com/openplayerjs/openplayerjs/pull/467)) @renovate[bot]
 - **[config]** migrate config renovate.json ([#463](https://github.com/openplayerjs/openplayerjs/pull/463)) @renovate[bot]

--- a/scripts/changelog-config.cjs
+++ b/scripts/changelog-config.cjs
@@ -59,4 +59,33 @@ const SCOPE_TO_PACKAGE = {
   youtube: { dir: 'packages/youtube', name: '@openplayerjs/youtube' },
 };
 
-module.exports = { TYPE_SECTIONS, SECTION_ORDER, PACKAGES, SCOPE_TO_PACKAGE };
+/**
+ * Maps a git author name (`%an`) to a GitHub login, so changelog credits render
+ * as real @mentions. Keyed on the name rather than the email because the same
+ * contributor commits under several addresses over the years.
+ *
+ * Bot authors ('renovate[bot]', 'dependabot[bot]') already commit under their
+ * exact GitHub login and need no entry here.
+ */
+const AUTHOR_ALIASES = {
+  'Rafael Miranda': 'rafa8626',
+  'Snyk bot': 'snyk-bot',
+};
+
+/**
+ * Render a git author name as a changelog credit.
+ *
+ * A GitHub login never contains whitespace, so an unmapped multi-word name
+ * cannot be mentioned safely — `@Nejc Sever` would either dangle or, worse,
+ * notify whoever happens to own `@Nejc`. Those fall back to the plain name with
+ * no `@`; add an AUTHOR_ALIASES entry to turn one into a real mention.
+ */
+function authorCredit(author) {
+  const name = String(author ?? '').trim();
+  if (!name) return '';
+  const alias = AUTHOR_ALIASES[name];
+  if (alias) return `@${alias}`;
+  return /\s/.test(name) ? name : `@${name}`;
+}
+
+module.exports = { TYPE_SECTIONS, SECTION_ORDER, PACKAGES, SCOPE_TO_PACKAGE, AUTHOR_ALIASES, authorCredit };

--- a/scripts/orchestrate-release.cjs
+++ b/scripts/orchestrate-release.cjs
@@ -36,7 +36,7 @@ const { tmpdir } = require('os');
 
 // TYPE_SECTIONS and SECTION_ORDER are the single source of truth — shared with
 // split-changelog.cjs.  Do not duplicate them here.
-const { TYPE_SECTIONS, SECTION_ORDER, SCOPE_TO_PACKAGE } = require('./changelog-config.cjs');
+const { TYPE_SECTIONS, SECTION_ORDER, SCOPE_TO_PACKAGE, authorCredit } = require('./changelog-config.cjs');
 
 // ─── Commit body helpers ──────────────────────────────────────────────────────
 
@@ -178,9 +178,10 @@ function generateReleaseNotes(version, pkgs, prevTags, lockedToCore = new Set())
       ? `([#${pr}](https://github.com/openplayerjs/openplayerjs/pull/${pr}))`
       : `(${hash.slice(0, 7)})`;
     const bodyLines = cleanBody(body);
+    const credit = authorCredit(author);
     const text = bodyLines
-      ? `- ${scopePrefix}${desc} ${ref} @${author}\n${bodyLines}`
-      : `- ${scopePrefix}${desc} ${ref} @${author}`;
+      ? `- ${scopePrefix}${desc} ${ref} ${credit}\n${bodyLines}`
+      : `- ${scopePrefix}${desc} ${ref} ${credit}`;
     return { sectionName, scope, text };
   }
 
@@ -532,6 +533,52 @@ function getGithubToken() {
   return null;
 }
 
+/**
+ * Verify the GitHub token BEFORE anything is published.
+ *
+ * The GitHub Release step deliberately never fails a release (see
+ * createGitHubRelease), so a dead token used to surface only as a 401 after the
+ * packages were already on npm — unfixable without a version bump. Checking up
+ * front turns that into a clean abort.
+ *
+ * Note the token precedence: an ambient GITHUB_TOKEN shadows the one in .env, so
+ * a stale export in a shell profile silently wins over a freshly updated .env.
+ * The reported source makes that visible.
+ */
+function preflightGithubToken() {
+  if (isDryRun) return;
+  const token = getGithubToken();
+  if (!token) {
+    console.warn('\n⚠ No GITHUB_TOKEN found (env or .env) — the GitHub Release step will be skipped.\n');
+    return;
+  }
+  const source = process.env.GITHUB_TOKEN ? 'ambient env' : '.env';
+  let status = '000';
+  try {
+    status = execSync(
+      `curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/user`,
+      { cwd: ROOT, encoding: 'utf8', env: { ...process.env, GH_TOKEN: token }, stdio: ['pipe', 'pipe', 'pipe'] },
+    ).trim();
+  } catch {
+    // Network failure is not a reason to block a release; the release step logs it.
+    console.warn(`\n⚠ Could not reach api.github.com to verify GITHUB_TOKEN (from ${source}) — continuing.\n`);
+    return;
+  }
+  if (status === '200') {
+    console.log(`✔ GITHUB_TOKEN (from ${source}) verified.\n`);
+    return;
+  }
+  console.error(
+    `\n✖ GITHUB_TOKEN (from ${source}) was rejected by GitHub (HTTP ${status}).\n` +
+    `  Aborting BEFORE publishing — nothing has been released.\n` +
+    (source === 'ambient env'
+      ? `  An ambient GITHUB_TOKEN overrides .env; if you just updated .env, clear the stale\n` +
+        `  export (e.g. in ~/.zshenv) or update it there instead.\n`
+      : `  Mint a new token with 'repo' scope (or fine-grained Contents: read & write).\n`),
+  );
+  process.exit(1);
+}
+
 /** Current HEAD commit SHA — used as target_commitish for the umbrella tag. */
 function headSha() {
   return execSync('git rev-parse HEAD', {
@@ -635,12 +682,13 @@ function getPlannedVersion(pkg) {
 
 // ─── Exports (for testing / tooling) ─────────────────────────────────────────
 
-module.exports = { generateReleaseNotes, readVersion, getLastTag };
+module.exports = { generateReleaseNotes, readVersion, getLastTag, preflightGithubToken };
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 if (require.main !== module) return; // allow require() without side-effects
 
+preflightGithubToken();
 checkTagAncestry();
 
 const coreTag = getLastTag('core');


### PR DESCRIPTION
Two fixes to the release orchestrator, both prompted by the v3.6.1 run.

Token preflight: createGitHubRelease deliberately never fails a release, so an expired token surfaced only as a 401 *after* the packages were already on npm — leaving a release that could not be completed without a version bump. preflightGithubToken() now validates the token against GET /user before any publishing and aborts cleanly if it is rejected.

The check also names which source the token came from. Precedence is ambient env over .env, so a stale export in a shell profile silently beats a freshly updated .env — the exact cause of the v3.6.1 failure, and invisible from a bare "Bad credentials". A missing token still only warns (the release step already skips gracefully), and dry runs skip the check so they need no credentials.

Author attribution: entries were rendered from the git author name (%an), producing "@Rafael Miranda" — not a valid GitHub handle. Map author names to logins via AUTHOR_ALIASES in the shared changelog config, keyed on name rather than email since the same contributor commits under five different addresses. Unmapped multi-word names now render without the "@" instead of emitting a broken mention that could notify an unrelated account. Bots already commit under their exact login and are unaffected.

Also sweeps the 149 existing "@Rafael Miranda" credits in CHANGELOG.md to @rafa8626. Normally generated files are not hand-edited, but these are a historical record that is never regenerated.