### PR TITLE
perf(player): cache root offset in progress tooltip pointermove handler

### DIFF
--- a/packages/player/__tests__/player.controls.progress.branches.test.ts
+++ b/packages/player/__tests__/player.controls.progress.branches.test.ts
@@ -519,3 +519,40 @@ test('pointermove middle position covers pos -= half (line 293) and out-of-range
   // percentage=1.5 > 1 → tooltip class removed (line 296)
   expect(tooltip.classList.contains('op-controls__tooltip--visible')).toBe(false);
 });
+
+test('pointermove reads the player root offset only once per event (no redundant getBoundingClientRect)', () => {
+  const p = makeCore();
+  setDuration(p.media, 100);
+
+  const opPlayer = document.createElement('div');
+  opPlayer.className = 'op-player';
+  document.body.appendChild(opPlayer);
+  opPlayer.appendChild(p.media);
+  Object.defineProperty(opPlayer, 'offsetWidth', { value: 500, configurable: true });
+
+  const c = createProgressControl();
+  const el = c.create(p);
+  opPlayer.appendChild(el);
+
+  const tooltip = el.querySelector('.op-controls__tooltip') as HTMLElement;
+  Object.defineProperty(el, 'offsetWidth', { value: 200, configurable: true });
+  Object.defineProperty(tooltip, 'offsetWidth', { value: 60, configurable: true });
+
+  let rootRectCalls = 0;
+  const originalRect = opPlayer.getBoundingClientRect.bind(opPlayer);
+  opPlayer.getBoundingClientRect = () => {
+    rootRectCalls += 1;
+    return originalRect();
+  };
+
+  // Middle-position branch (pos -= half) — the one that previously read offset(root) twice.
+  const moveEvent = new MouseEvent('pointermove', { bubbles: true, cancelable: true });
+  Object.defineProperty(moveEvent, 'pageX', { value: 300 });
+  el.dispatchEvent(moveEvent);
+
+  expect(rootRectCalls).toBe(1);
+  // Behavior unchanged from the "pos -= half" case above: percentage=1.5 > 1 hides the tooltip,
+  // and pos is computed from the same rootLeft value in both the clamp checks and the fallback.
+  expect(tooltip.classList.contains('op-controls__tooltip--visible')).toBe(false);
+  expect(tooltip.style.left).toBe('270px'); // pos = (300 - 0) - 30 (half) = 270
+});

--- a/packages/player/src/controls/progress.ts
+++ b/packages/player/src/controls/progress.ts
@@ -301,9 +301,10 @@ export class ProgressControl extends BaseControl {
 
         const root = this.resolvePlayerRoot();
         const limit = root.offsetWidth - tooltip.offsetWidth;
+        const rootLeft = offset(root).left;
 
-        if (pos <= 0 || x - offset(root).left <= half) pos = 0;
-        else if (x - offset(root).left >= limit) pos = limit - offset(slider).left - 10;
+        if (pos <= 0 || x - rootLeft <= half) pos = 0;
+        else if (x - rootLeft >= limit) pos = limit - offset(slider).left - 10;
         else pos -= half;
 
         if (percentage >= 0 && percentage <= 1) tooltip.classList.add('op-controls__tooltip--visible');


### PR DESCRIPTION
## Summary

The progress-bar tooltip's `pointermove` handler computed `offset(root).left` twice per event — once for the "clamp to 0" check, once for the "clamp to li