### PR TITLE
refactor(ads): avoid redundant getVastInputFromBreak calls in AdScheduler

### DIFF
--- a/packages/ads/__tests__/schedule.branches.test.ts
+++ b/packages/ads/__tests__/schedule.branches.test.ts
@@ -336,6 +336,51 @@ describe('AdScheduler.getDueMidrollBreaks', () => {
   });
 });
 
+describe('AdScheduler break-lookup methods avoid redundant getVastInputFromBreak calls (perf)', () => {
+  it('getPrerollBreak calls getVastInputFromBreak once per id-less candidate break', () => {
+    const breakCfg: AdsBreakConfig = {
+      at: 'preroll',
+      source: { type: 'VAST', src: 'https://example.com/preroll.xml' },
+    };
+    const sched = makeScheduler([], [breakCfg]);
+    const spy = jest.spyOn(sched, 'getVastInputFromBreak');
+
+    const result = sched.getPrerollBreak();
+
+    expect(result?.source?.src).toBe('https://example.com/preroll.xml');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('getPostrollBreak calls getVastInputFromBreak once per id-less candidate break', () => {
+    const breakCfg: AdsBreakConfig = {
+      at: 'postroll',
+      source: { type: 'VAST', src: 'https://example.com/postroll.xml' },
+    };
+    const sched = makeScheduler([]);
+    sched.resolvedBreaks = [breakCfg];
+    const spy = jest.spyOn(sched, 'getVastInputFromBreak');
+
+    const result = sched.getPostrollBreak();
+
+    expect(result?.source?.src).toBe('https://example.com/postroll.xml');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('getDueMidrollBreaks calls getVastInputFromBreak once per id-less resolved break', () => {
+    const sched = makeScheduler([]);
+    sched.resolvedBreaks = [
+      { at: 10, source: { type: 'VAST', src: 'https://example.com/m1.xml' } },
+      { at: 30, source: { type: 'VAST', src: 'https://example.com/m2.xml' } },
+    ];
+    const spy = jest.spyOn(sched, 'getVastInputFromBreak');
+
+    const due = sched.getDueMidrollBreaks(30);
+
+    expect(due).toHaveLength(2);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('AdScheduler.inferSourceTypeForUrl', () => {
   it('returns NONLINEAR when the exact url is a NONLINEAR source', () => {
     const sched = makeScheduler([{ type: 'NONLINEAR', src: 'https://example.com/nl.xml' }]);

--- a/packages/ads/src/schedule.ts
+++ b/packages/ads/src/schedule.ts
@@ -71,11 +71,17 @@ export function getVastInputFromBreakFn(b: AdsBreakConfig): { input?: VastInput;
   return { input: undefined, sourceType: undefined };
 }
 
+/** Derives a break's id from an already-computed VAST input, skipping a redundant re-derivation. */
+function breakIdFromInput(b: AdsBreakConfig, input?: VastInput, sourceType?: AdsSourceType): string {
+  if (b.id) return b.id;
+  const key = input?.kind === 'url' ? input.value : 'xml';
+  return `${String(b.at)}:${sourceType || 'VAST'}:${key}`;
+}
+
 export function getBreakIdFn(b: AdsBreakConfig): string {
   if (b.id) return b.id;
   const { input, sourceType } = getVastInputFromBreakFn(b);
-  const key = input?.kind === 'url' ? input.value : 'xml';
-  return `${String(b.at)}:${sourceType || 'VAST'}:${key}`;
+  return breakIdFromInput(b, input, sourceType);
 }
 
 type PendingPercentBreak = {
@@ -149,23 +155,24 @@ export class AdScheduler {
   getBreakId(b: AdsBreakConfig): string {
     if (b.id) return b.id;
     const { input, sourceType } = this.getVastInputFromBreak(b);
-    const key = input?.kind === 'url' ? input.value : 'xml';
-    return `${String(b.at)}:${sourceType || 'VAST'}:${key}`;
+    return breakIdFromInput(b, input, sourceType);
   }
 
   getPrerollBreak(): AdsBreakConfig | undefined {
     for (const b of this.resolvedBreaks) {
       if (b.at !== 'preroll') continue;
-      if (!this.getVastInputFromBreak(b).input) continue;
-      const id = this.getBreakId(b);
+      const { input, sourceType } = this.getVastInputFromBreak(b);
+      if (!input) continue;
+      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       return b;
     }
 
     for (const b of this.cfg.breaks) {
       if (b.at !== 'preroll') continue;
-      if (!this.getVastInputFromBreak(b).input) continue;
-      const id = this.getBreakId(b);
+      const { input, sourceType } = this.getVastInputFromBreak(b);
+      if (!input) continue;
+      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       return b;
     }
@@ -185,8 +192,9 @@ export class AdScheduler {
   getPostrollBreak(): AdsBreakConfig | undefined {
     for (const b of this.resolvedBreaks) {
       if (b.at !== 'postroll') continue;
-      if (!this.getVastInputFromBreak(b).input) continue;
-      const id = this.getBreakId(b);
+      const { input, sourceType } = this.getVastInputFromBreak(b);
+      if (!input) continue;
+      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       return b;
     }
@@ -209,8 +217,9 @@ export class AdScheduler {
     const due: AdsBreakConfig[] = [];
     for (const b of this.resolvedBreaks) {
       if (typeof b.at !== 'number') continue;
-      if (!this.getVastInputFromBreak(b).input) continue;
-      const id = this.getBreakId(b);
+      const { input, sourceType } = this.getVastInputFromBreak(b);
+      if (!input) continue;
+      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       if (currentTime + (this.cfg.breakTolerance ?? 0.25) >= b.at) due.push(b);
     }


### PR DESCRIPTION
## Summary

`getPrerollBreak()`, `getPostrollBreak()`, and `getDueMidrollBreaks()` each checked `getVastInputFromBreak(b).input` to skip a break, then called `getBreakId(b)`, which internally re-derives `getVastInputFromBreak(b)` whenever the break has no explicit `id`. `getDueMidrollBreaks()` runs on every `timeupdate` tick, so id-less midroll breaks paid for that derivation twice per tick.

Extracted the id-derivation into a module-level, non-exported `breakIdFromInput()` helper and threaded the already-computed `input`/`sourceType` through instead of recomputing.

## Why it's safe (zero behavior change)

- New regression tests spy on `AdScheduler.getVastInputFromBreak` and assert per-break call counts for all three methods. Confirmed each fails on the pre-change code (2/2/4 calls) and passes post-change (1/1/2 calls), with identical break-selection output in both cases.
- Full G0 gate green: `type-check` ✅, `lint` ✅, `build` ✅, `test` ✅ — 1152 tests passing, coverage 96.15/85.82/92.55/98.38 (all ≥85%).
- No new `as any`/`@ts-ignore`/`@ts-expect-error`/`eslint-disable`.
- `packages/ads/dist/types/schedule.d.ts` diffed master vs. this branch: byte-identical. (First attempt used a private class method instead of a module-level function, which DID change the emitted `.d.ts` — TypeScript emits `private` members into declaration files even though they're inaccessible to consumers, so that approach was reclassified and redone.)
- Touches only `packages/ads/src/schedule.ts` and its `__tests__` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)