### PR TITLE
refactor(ads): dedupe SCTE35-IN break-id resolution in SsaiAdStrategy

### DIFF
--- a/packages/ads/__tests__/ads.ssai.test.ts
+++ b/packages/ads/__tests__/ads.ssai.test.ts
@@ -368,6 +368,23 @@ describe('SsaiAdStrategy — EXT-X-DATERANGE (scte35Out/In properties)', () => {
     expect(events).toEqual(['start', 'end']);
     strategy.destroy();
   });
+
+  test('legacy scte35In property resolves -in suffix to base break id', () => {
+    const { ctx, bus, video } = makeCtx();
+    const strategy = new SsaiAdStrategy();
+    const track = makeMetadataTrack(video);
+    strategy.init(ctx, {});
+
+    const ended: string[] = [];
+    bus.on('ads:break:end', () => ended.push('end'));
+
+    // Start break with base id 'legacy-base'; end cue arrives with id 'legacy-base-in'
+    fireCueChange(track, [makeDateRangeCue('legacy-base', 'out')]);
+    fireCueChange(track, [makeDateRangeCue('legacy-base-in', 'in')]);
+
+    expect(ended).toHaveLength(1);
+    strategy.destroy();
+  });
 });
 
 describe('SsaiAdStrategy — deduplication', () => {

--- a/packages/ads/src/strategies/ssai.ts
+++ b/packages/ads/src/strategies/ssai.ts
@@ -10,6 +10,14 @@ type SsaiBreak = {
   firedQuartiles: Set<number>;
 };
 
+/**
+ * Resolves a SCTE35-IN cue's id back to its open break's id. Some hls.js builds/tests mint a
+ * `-in` suffix on the end-cue id instead of reusing the start-cue id verbatim.
+ */
+function resolveEndBreakId(activeBreaks: ReadonlyMap<string, SsaiBreak>, id: string): string {
+  return activeBreaks.has(id) ? id : id.endsWith('-in') ? id.slice(0, -3) : id;
+}
+
 /** Non-standard SCTE-35 fields hls.js attaches to metadata cues (DataCue / VTTCue / legacy). */
 type RawCue = TextTrackCue & {
   data?: ArrayBuffer;
@@ -134,7 +142,7 @@ export class SsaiAdStrategy implements AdSessionStrategy {
       return;
     }
     if (value?.key === 'SCTE35-IN') {
-      const resolvedId = this.activeBreaks.has(id) ? id : id.endsWith('-in') ? id.slice(0, -3) : id;
+      const resolvedId = resolveEndBreakId(this.activeBreaks, id);
       this.endBreak(resolvedId);
       return;
     }
@@ -149,7 +157,7 @@ export class SsaiAdStrategy implements AdSessionStrategy {
       return;
     }
     if (hasSpliceIn) {
-      const resolvedId = this.activeBreaks.has(id) ? id : id.endsWith('-in') ? id.slice(0, -3) : id;
+      const resolvedId = resolveEndBreakId(this.activeBreaks, id);
       this.endBreak(resolvedId);
       return;
     }
@@ -165,7 +173,7 @@ export class SsaiAdStrategy implements AdSessionStrategy {
           isFinite(cue.endTime) && cue.endTime > cue.startTime ? cue.endTime - cue.startTime : cmd.durationSecs;
         this.startBreak(id, dur, cue.startTime);
       } else {
-        const resolvedId = this.activeBreaks.has(id) ? id : id.endsWith('-in') ? id.slice(0, -3) : id;
+        const resolvedId = resolveEndBreakId(this.activeBreaks, id);
         this.endBreak(resolvedId);
       }
     }


### PR DESCRIPTION
## What

`processCue()` repeated the exact same expression three times — once per SCTE-35 IN detection path (EXT-X-DAT