### PR TITLE
fix(ci): revert overrides edit when audit-fix's pnpm install fails

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -99,6 +99,15 @@ jobs:
           SUMMARY_PATH: ${{ runner.temp }}/audit-fix-summary.json
         run: |
           node scripts/audit-fix-report.cjs --format=commit "$SUMMARY_PATH" > "$RUNNER_TEMP/commit-message.txt"
+          # Defense in depth: scripts/audit-fix.cjs now reverts pnpm-workspace.yaml/
+          # pnpm-lock.yaml whenever nothing was verified fixed, so this step's `if`
+          # condition (a real diff) and a non-empty commit message (fixed.length > 0)
+          # should never disagree. Guard anyway rather than let `git commit -F` abort
+          # the job on an empty message if that invariant is ever broken again.
+          if [ ! -s "$RUNNER_TEMP/commit-message.txt" ]; then
+            echo "No advisories were verified as fixed — nothing to commit." >&2
+            exit 0
+          fi
           git config user.name 'openplayerjs-bot'
           git config user.email 'actions@github.com'
           git add pnpm-workspace.yaml pnpm-lock.yaml

--- a/scripts/audit-fix.cjs
+++ b/scripts/audit-fix.cjs
@@ -279,6 +279,17 @@ function main() {
         'bypass it), not auto-overridden.',
     );
     process.stderr.write(String(err.stdout || err.message) + '\n');
+    // updateOverrides() already wrote pnpm-workspace.yaml above; pnpm may also have
+    // partially rewritten pnpm-lock.yaml before failing. Neither edit was verified, so
+    // revert both to their committed state — otherwise a summary reporting `fixed: []`
+    // (correct: nothing was verified) disagrees with a dirty git tree, the CI job's
+    // change-detection step sees the untracked edit and tries to commit it anyway, and
+    // the commit message renders empty for zero fixed advisories, aborting `git commit`.
+    try {
+      sh('git', ['checkout', '--', 'pnpm-workspace.yaml', 'pnpm-lock.yaml']);
+    } catch (revertErr) {
+      fail(`Also failed to revert pnpm-workspace.yaml/pnpm-lock.yaml: ${revertErr.message}`);
+    }
     writeSummary({ clean: false, fixed: [], skipped: [...skipped, ...fixed.map(f => ({ ...f, reason: 'pnpm install failed post-override (see job log)' }))] });
     process.exit(1);
   }


### PR DESCRIPTION
Ported from the premium monorepo's downstream consumer repo, which hit this live: the audit-fix job aborted with 'Aborting commit due to empty commit message.'

Root cause: updateOverrides() writes pnpm-workspace.yaml before pnpm install is attempted. When that install then fails (e.g. blocked by a minimumReleaseAge supply-chain cooldown), the catch block correctly reports fixed: [] but never reverted the file it had already written. The workflow's 'Check for changes' step then saw a real diff and ran the commit step; audit-fix-report.cjs correctly emits nothing for zero fixed advisories, producing an empty commit-message.txt, and git refused to commit an empty message.

Fix: on install failure, git checkout -- both pnpm-workspace.yaml and pnpm-lock.yaml back to their committed state (pnpm may partially rewrite the lockfile before failing too), so 'nothing verified as fixed' always means 'nothing changed on disk.' Also added a defense-in-depth guard in the workflow's commit step that skips committing on an empty message file, independent of the script-level fix.

Verified the revert mechanism in an isolated git worktree: dirtied both files the same way updateOverrides()+a partial pnpm write would, ran the exact 'git checkout --' command the fix issues, confirmed both files come back byte-identical to the committed originals and 'git diff --quiet' correctly reports no changes afterward.