### PR TITLE
refactor(player): dedupe redundant textTracks reads in CaptionsControl

### DIFF
--- a/packages/player/__tests__/player.controls.captions.test.ts
+++ b/packages/player/__tests__/player.controls.captions.test.ts
@@ -34,6 +34,33 @@ function mockTextTracksOn(media: HTMLMediaElement, tracks: MockTrack[]): MockTra
   return trackObjs;
 }
 
+/** Same shape as mockTextTracksOn, but counts every `media.textTracks` getter read. */
+function mockTextTracksWithReadCounter(media: HTMLMediaElement, tracks: MockTrack[]): { reads: () => number } {
+  const trackObjs: MockTrack[] = tracks.map((t) => ({ ...t }));
+  const trackList = {
+    length: trackObjs.length,
+    ...Object.fromEntries(trackObjs.map((t, i) => [i, t])),
+    item: (i: number) => trackObjs[i] as unknown as TextTrack,
+    getTrackById: (_id: string) => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    onchange: null,
+    onaddtrack: null,
+    onremovetrack: null,
+  } as unknown as TextTrackList;
+
+  let readCount = 0;
+  Object.defineProperty(media, 'textTracks', {
+    configurable: true,
+    get() {
+      readCount += 1;
+      return trackList;
+    },
+  });
+  return { reads: () => readCount };
+}
+
 // ─── createCaptionsControl factory ───────────────────────────────────────────
 
 describe('createCaptionsControl factory', () => {
@@ -816,6 +843,69 @@ describe('CaptionsControl – provider-based captions', () => {
     expect(provider._active).toBeNull();
 
     localStorage.removeItem('op:caption:track');
+    control.destroy();
+  });
+});
+
+// ─── refresh() reads textTracks once per pass (perf) ────────────────────────
+
+describe('CaptionsControl – refresh avoids a redundant textTracks read', () => {
+  test('refresh() reads media.textTracks once when computing button state', () => {
+    const player = makeCore();
+    const video = player.media as HTMLVideoElement;
+    const counter = mockTextTracksWithReadCounter(video, [
+      { kind: 'captions', label: 'English', language: 'en', mode: 'disabled' },
+    ]);
+
+    const control = new CaptionsControl();
+    control.create(player);
+
+    const baseline = counter.reads();
+    player.events.emit('loadedmetadata'); // triggers exactly one refresh() call
+
+    // refresh() derives both "has tracks" and "is showing" from a single
+    // listNativeTracks() list, instead of reading textTracks a second time
+    // inside getNativeShowingIndex.
+    expect(counter.reads() - baseline).toBe(1);
+
+    control.destroy();
+  });
+
+  test('toggling captions on (ad video) reads textTracks once to resolve showing state and fallback index', async () => {
+    const player = makeCore();
+    const overlayMgr = getOverlayManager(player);
+    const adVideo = document.createElement('video');
+    const counter = mockTextTracksWithReadCounter(adVideo, [
+      { kind: 'captions', label: 'Ad EN', language: 'en', mode: 'disabled' },
+    ]);
+
+    const control = new CaptionsControl();
+    const el = control.create(player);
+    document.body.appendChild(el);
+
+    overlayMgr.activate({
+      id: 'ads',
+      priority: 100,
+      mode: 'normal',
+      duration: 10,
+      value: 0,
+      canSeek: false,
+      fullscreenVideoEl: adVideo as HTMLElement,
+    });
+
+    await Promise.resolve();
+
+    const baseline = counter.reads();
+    (el as HTMLButtonElement).click();
+
+    // Click handler: 1 read to resolve both "showing" and the lastAdTrackIndex fallback
+    // (was 2: one via getNativeShowingIndex(adVideo), one explicit listNativeTracks(adVideo))
+    // + 1 read inside selectNativeIndex (untouched by this change).
+    // Trailing refresh(): 1 read reused for both "has tracks" and "is showing"
+    // (was 2: listNativeTracks(adVideo) + a second read via getNativeShowingIndex(adVideo)).
+    // Total: 3 reads post-fix, was 5 pre-fix.
+    expect(counter.reads() - baseline).toBe(3);
+
     control.destroy();
   });
 });

--- a/packages/player/src/controls/captions.ts
+++ b/packages/player/src/controls/captions.ts
@@ -28,8 +28,9 @@ function listNativeTracks(media: HTMLMediaElement): { index: number; track: Text
   return out;
 }
 
-function getNativeShowingIndex(media: HTMLMediaElement): number | 'off' {
-  for (const x of listNativeTracks(media)) {
+/** Derives the showing index from an already-computed track list, skipping a redundant textTracks read. */
+function getShowingIndex(tracks: { index: number; track: TextTrack }[]): number | 'off' {
+  for (const x of tracks) {
     if (x.track.mode === 'showing') return x.index;
   }
   return 'off';
@@ -95,7 +96,7 @@ export class CaptionsControl extends BaseControl {
           const adTracks = listNativeTracks(adVideo);
           this.button.style.display = adTracks.length > 0 ? '' : 'none';
           if (adTracks.length > 0) {
-            const on = getNativeShowingIndex(adVideo) !== 'off';
+            const on = getShowingIndex(adTracks) !== 'off';
             this.button.classList.toggle('op-controls__captions--on', on);
             this.button.setAttribute('aria-pressed', on ? 'true' : 'false');
           }
@@ -111,7 +112,7 @@ export class CaptionsControl extends BaseControl {
       const hasTracks = nativeTracks.length > 0 || providerTracks.length > 0;
       this.button.style.display = hasTracks ? '' : 'none';
 
-      const on = provider ? provider.getActiveTrack() !== null : getNativeShowingIndex(core.media) !== 'off';
+      const on = provider ? provider.getActiveTrack() !== null : getShowingIndex(nativeTracks) !== 'off';
 
       this.button.classList.toggle('op-controls__captions--on', on);
       this.button.setAttribute('aria-pressed', on ? 'true' : 'false');
@@ -129,12 +130,12 @@ export class CaptionsControl extends BaseControl {
           // Toggle captions on the ad video. Use 'hidden' (not 'disabled') so
           // the browser keeps VTT data; 'disabled' discards it and re-enabling
           // silently fails.
-          const showing = getNativeShowingIndex(adVideo);
+          const adTracks = listNativeTracks(adVideo);
+          const showing = getShowingIndex(adTracks);
           if (showing === 'off') {
-            const tracks = listNativeTracks(adVideo);
             // Use lastAdTrackIndex (ad-specific) — not lastSelectedIndex which
             // tracks content-media state and may point to a wrong index.
-            const idx = this.lastAdTrackIndex ?? tracks[0]?.index;
+            const idx = this.lastAdTrackIndex ?? adTracks[0]?.index;
             if (typeof idx === 'number') selectNativeIndex(adVideo, idx, 'hidden');
           } else {
             setNativeAllHidden(adVideo);
@@ -154,10 +155,10 @@ export class CaptionsControl extends BaseControl {
               }
             }
           } else {
-            const showing = getNativeShowingIndex(core.media);
+            const nativeTracks = listNativeTracks(core.media);
+            const showing = getShowingIndex(nativeTracks);
             if (showing === 'off') {
-              const tracks = listNativeTracks(core.media);
-              const idx = this.lastSelectedIndex ?? tracks[0]?.index;
+              const idx = this.lastSelectedIndex ?? nativeTracks[0]?.index;
               if (typeof idx === 'number') selectNativeIndex(core.media, idx);
             } else {
               setNativeAllOff(core.media);
@@ -185,7 +186,7 @@ export class CaptionsControl extends BaseControl {
           // Show ad video's caption tracks in the submenu
           const adTracks = listNativeTracks(adVideo);
           if (!adTracks.length) return null;
-          const showing = getNativeShowingIndex(adVideo);
+          const showing = getShowingIndex(adTracks);
           return {
             id: 'captions',
             label,
@@ -251,7 +252,7 @@ export class CaptionsControl extends BaseControl {
         }
 
         if (!nativeTracks.length) return null;
-        const showing = getNativeShowingIndex(core.media);
+        const showing = getShowingIndex(nativeTracks);
 
         return {
           id: 'captions',


### PR DESCRIPTION
getNativeShowingIndex(media) internally re-ran listNativeTracks(media), but every call site already had (or could reorder to compute) that same track list in scope for a second purpose (visibility check, submenu items, or the toggle-off fallback index). That meant media.textTracks got iterated twice per logical read across all 6 call sites, including refresh() — which fires on every overlay:changed tick during ad playback via BaseControl's subscription.

Replaced getNativeShowingIndex(media) with a pure getShowingIndex(tracks) that derives the showing index from an already-computed track list, and updated all 6 call sites to reuse the list already in scope (reordering the two click-handler branches so the list is computed once, before the showing check, instead of after it).

Safe: no public signature, event, or behavior changed — listNativeTracks/ getShowingIndex/getNativeShowingIndex-replacement are all module-private to captions.ts; only createCaptionsControl is exported. Implemented as a module-level function (not a class method) to keep dist/types/*.d.ts byte-identical, per the private-member .d.ts emission gotcha found in prior optimize passes.

New regression tests spy on the `textTracks` getter to pin the exact read count: both fail on the pre-change code (2 and 5 reads) and pass post-change (1 and 3 reads), verified by stashing the source fix and re-running.

Verified: type-check, lint, build, and full test suite (1156 tests, 79 suites) all green; coverage 96.15/85.91/92.56/98.38 (≥85% threshold); no new as any/@ts-ignore/@ts-expect-error/eslint-disable; touched files limited to packages/player/src/controls/captions.ts and its __tests__ counterpart; dist/types/controls/captions.d.ts byte-identical to master (only the .d.ts.map sourcemap differs, from shifted source lines).