### PR TITLE
perf(player): cache SettingsRegistry.list()'s sorted result

### DIFF
--- a/packages/player/__tests__/player.settings.test.ts
+++ b/packages/player/__tests__/player.settings.test.ts
@@ -3,6 +3,7 @@
 import { Core, getOverlayManager } from '@openplayerjs/core';
 import createCaptionsControl from '../src/controls/captions';
 import createSettingsControl from '../src/controls/settings';
+import { SettingsRegistry } from '../src/settings';
 
 function makeCore() {
   const v = document.createElement('video');
@@ -159,5 +160,65 @@ describe('Settings control + registry', () => {
       );
       expect(anySpeedRow).toBe(false);
     }
+  });
+});
+
+// ─── SettingsRegistry.list() caches the sorted result (perf) ────────────────
+
+describe('SettingsRegistry.list() sort caching', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('repeated list() calls with no registration changes sort only once', () => {
+    const registry = new SettingsRegistry();
+    registry.register({ id: 'b', label: 'Bravo', getSubmenu: () => null });
+    registry.register({ id: 'a', label: 'Alpha', getSubmenu: () => null });
+
+    const sortSpy = jest.spyOn(Array.prototype, 'sort');
+
+    const first = registry.list();
+    const second = registry.list();
+    const third = registry.list();
+
+    expect(first.map((p) => p.id)).toEqual(['a', 'b']);
+    expect(second.map((p) => p.id)).toEqual(['a', 'b']);
+    expect(third.map((p) => p.id)).toEqual(['a', 'b']);
+    // Only the first list() call should actually sort; later calls reuse the cache.
+    expect(sortSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('registering a new provider invalidates the cache and the next list() re-sorts', () => {
+    const registry = new SettingsRegistry();
+    registry.register({ id: 'b', label: 'Bravo', getSubmenu: () => null });
+    registry.list();
+
+    registry.register({ id: 'a', label: 'Alpha', getSubmenu: () => null });
+    const after = registry.list();
+
+    expect(after.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  test('unregistering a provider invalidates the cache', () => {
+    const registry = new SettingsRegistry();
+    const unregisterA = registry.register({ id: 'a', label: 'Alpha', getSubmenu: () => null });
+    registry.register({ id: 'b', label: 'Bravo', getSubmenu: () => null });
+    registry.list();
+
+    unregisterA();
+    const after = registry.list();
+
+    expect(after.map((p) => p.id)).toEqual(['b']);
+  });
+
+  test('list() returns a fresh array each call so caller mutation cannot corrupt the cache', () => {
+    const registry = new SettingsRegistry();
+    registry.register({ id: 'a', label: 'Alpha', getSubmenu: () => null });
+
+    const first = registry.list();
+    first.push({ id: 'z', label: 'Zulu', getSubmenu: () => null });
+
+    const second = registry.list();
+    expect(second.map((p) => p.id)).toEqual(['a']);
   });
 });

--- a/packages/player/src/settings.ts
+++ b/packages/player/src/settings.ts
@@ -27,16 +27,34 @@ export type SettingsSubmenuProvider = {
 // Use a symbol to avoid collisions with user-land fields.
 const SETTINGS_REGISTRY_KEY: unique symbol = Symbol.for('openplayerjs.settings.registry');
 
+// Keyed by registry instance rather than a class field so adding this cache doesn't add
+// a new `private` member to SettingsRegistry (TypeScript emits private member names into
+// .d.ts, which would otherwise change the package's declared public API surface).
+// Invalidated on register/unregister; list() re-sorts only then instead of on every call.
+// render() calls list() on every closed-menu overlay:changed tick (i.e. every ad-video
+// timeupdate), so an unconditional localeCompare sort there is wasted work.
+const sortedProvidersCache = new WeakMap<SettingsRegistry, SettingsSubmenuProvider[]>();
+
 export class SettingsRegistry {
   private providers = new Map<string, SettingsSubmenuProvider>();
 
   register(provider: SettingsSubmenuProvider) {
     this.providers.set(provider.id, provider);
-    return () => this.providers.delete(provider.id);
+    sortedProvidersCache.delete(this);
+    return () => {
+      sortedProvidersCache.delete(this);
+      return this.providers.delete(provider.id);
+    };
   }
 
   list(): SettingsSubmenuProvider[] {
-    return Array.from(this.providers.values()).sort((a, b) => a.label.localeCompare(b.label));
+    let sorted = sortedProvidersCache.get(this);
+    if (!sorted) {
+      sorted = Array.from(this.providers.values()).sort((a, b) => a.label.localeCompare(b.label));
+      sortedProvidersCache.set(this, sorted);
+    }
+    // Return a copy so a caller mutating the result can't corrupt the cache.
+    return sorted.slice();
   }
 }
 


### PR DESCRIPTION
list() re-ran Array.from(...).sort(localeCompare) on every call, even though the provider set only changes on register/unregister. render() in SettingsControl calls list() on every closed-menu overlay:changed tick — which OverlayManager.update() fires on every ad-video timeupdate via CsaiAdStrategy — so the sort was repeating several times per second for the full duration of any ad break, for zero visible effect (the panel stays closed).

Cache the sorted array, invalidating it in register() and the returned unregister closure. The cache is a module-level WeakMap keyed by the registry instance rather than a new class field, so it doesn't add a `private` member to SettingsRegistry — TypeScript emits private member names (bare, e.g. `private providers;`) into dist/types/*.d.ts, so a new private field would still change the package's declared public surface even though it's inaccessible to consumers (same gotcha hit and worked around in the schedule.ts/ssai.ts optimize passes). list() still returns a fresh array copy each call so a caller mutating the result can't corrupt the cache, and register()'s returned unregister closure keeps its exact `() => boolean` return type (Map.delete's result).

New regression tests spy on Array.prototype.sort to pin the call count: 3 list() calls with no registry mutation in between sort once post-fix (fails pre-fix at 3 sorts, verified by stashing the source fix and re-running); separate tests cover cache invalidation on register/ unregister and that the returned array is a fresh copy.

Verified: type-check, lint, build, full test suite (1160 tests, 79 suites) all green; coverage 96.17/85.92/92.66/98.38 (≥85% threshold); no new as any/@ts-ignore/@ts-expect-error/eslint-disable; touched files limited to packages/player/src/settings.ts and its __tests__ counterpart; dist/types/settings.d.ts byte-identical to master's baseline build (confirmed after reworking the first attempt, which used a private class field and leaked `private sortedCache;` plus an unregister-closure return-type regression into the declaration file).