### PR TITLE
perf(ads): hoist setSafeHTMLFn's blocked-tags Set to module scope

### DIFF
--- a/packages/ads/__tests__/ad-dom.branches.test.ts
+++ b/packages/ads/__tests__/ad-dom.branches.test.ts
@@ -162,6 +162,32 @@ describe('setSafeHTMLFn', () => {
     expect(imgs[2].getAttribute('src')).toBe('http://example.com/c.png');
     expect(imgs[3].getAttribute('src')).toBe('https://example.com/d.png');
   });
+
+  it('does not reconstruct the blocked-tags Set on repeated calls (perf)', () => {
+    // The Set constructor calls Set.prototype.add once per seed element when built
+    // from an iterable, so spying on `add` (an ordinary method, unlike the
+    // constructor itself) detects a fresh 15-tag Set being built without needing
+    // to intercept `new Set(...)` directly.
+    const addSpy = jest.spyOn(Set.prototype, 'add');
+
+    const el1 = document.createElement('div');
+    const el2 = document.createElement('div');
+    const el3 = document.createElement('div');
+    setSafeHTMLFn(el1, '<p>one</p>');
+    setSafeHTMLFn(el2, '<script>bad()</script><p>two</p>');
+    setSafeHTMLFn(el3, '<iframe src="x"></iframe><p>three</p>');
+
+    // The blocked-tags Set is a module-level constant built once at import time,
+    // not rebuilt inside the function on every call.
+    expect(addSpy).not.toHaveBeenCalled();
+
+    // Sanitization still behaves correctly after the hoist.
+    expect(el2.querySelector('script')).toBeNull();
+    expect(el3.querySelector('iframe')).toBeNull();
+    expect(el1.querySelector('p')).not.toBeNull();
+
+    addSpy.mockRestore();
+  });
 });
 
 // ─── AdDomManager.setSafeHTML (instance method mirrors setSafeHTMLFn) ─────────

--- a/packages/ads/src/ad-dom.ts
+++ b/packages/ads/src/ad-dom.ts
@@ -5,33 +5,36 @@ import { computeSkipAtSeconds, extractSkipOffsetFromCreative } from './vast-pars
 
 // ─── Standalone export (no class state needed) ────────────────────────────────
 
+// Static blocklist, never varies per call — hoisted so setSafeHTMLFn (called once per
+// rendered companion/non-linear ad resource) doesn't rebuild this Set every invocation.
+const SAFE_HTML_BLOCKED_TAGS = new Set([
+  'SCRIPT',
+  'IFRAME',
+  'OBJECT',
+  'EMBED',
+  'LINK',
+  'STYLE',
+  'SVG',
+  'MATH',
+  'FORM',
+  'INPUT',
+  'TEXTAREA',
+  'SELECT',
+  'OPTION',
+  'META',
+  'BASE',
+]);
+
 export function setSafeHTMLFn(el: HTMLElement, html: string) {
   const tpl = document.createElement('template');
   tpl.innerHTML = String(html || '');
 
-  const blockedTags = new Set([
-    'SCRIPT',
-    'IFRAME',
-    'OBJECT',
-    'EMBED',
-    'LINK',
-    'STYLE',
-    'SVG',
-    'MATH',
-    'FORM',
-    'INPUT',
-    'TEXTAREA',
-    'SELECT',
-    'OPTION',
-    'META',
-    'BASE',
-  ]);
   const walker = document.createTreeWalker(tpl.content, NodeFilter.SHOW_ELEMENT);
   const toRemove: Element[] = [];
 
   while (walker.nextNode()) {
     const node = walker.currentNode as Element;
-    if (blockedTags.has(node.tagName)) {
+    if (SAFE_HTML_BLOCKED_TAGS.has(node.tagName)) {
       toRemove.push(node);
       continue;
     }


### PR DESCRIPTION
## What
`blockedTags` — a fixed, never-mutated 15-entry `Set` of HTML tag names — was constructed fresh inside `setSafeHTMLFn` on every call, even though its contents never vary. `setSafeHTMLFn` sanitizes VAST companion-ad and non-linear-ad HTML and is called once per rendered resource (`AdDomManager.setSafeHTML` / `AdsPlugin.setSafeHTML`), so every companion/non-linear ad shown rebuilt and rehashed the same 15-element Set for nothing.

Hoisted it to a module-level `const SAFE_HTML_BLOCKED_TAGS`.

## Why it's safe
- Not a class field, so no `dist/types/*.d.ts` risk from the private-member-emission gotcha found in prior optimize passes — it isn't exported either, so it has zero `.d.ts` footprint at all.
- `dist/types/` verified byte-identical to `master`'s baseline build.
- Same tag blocklist, same lookup results, same exported function signature (`setSafeHTMLFn(el, html)`).

## Tests
New regression test spies on `Set.prototype.add` (not the `Set` constructor itself — jest's default constructor-spy breaks native classes with `Constructor Set requires 'new'`, so spying on the ordinary `add()` method the constructor calls once per seed element is the safe way to detect a fresh Set being built) across 3 `setSafeHTMLFn` calls: expects zero `add()` calls post-fix (the Set is built once at import time, before the spy attaches) vs 45 pre-fix (3 calls × 15 tags) — verified by stashing the source fix and re-running.

## Verification
`type-check`, `lint`, `build`, full test suite (1161 tests, 79 suites) all green; coverage 96.17/85.92/92.66/98.38 (≥85% threshold); no new `as any`/`@ts-ignore`/`@ts-expect-error`/`eslint-disable`; touched files limited to `packages/ads/src/ad-dom.ts` and its `__tests__` counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
