### PR TITLE
refactor(hls): drop dead options param from onAdapterEvent bookkeeping

### DIFF
--- a/packages/hls/__tests__/engines.hls.branches.test.ts
+++ b/packages/hls/__tests__/engines.hls.branches.test.ts
@@ -254,6 +254,29 @@ describe('HlsMediaEngine branch coverage', () => {
     expect(engine.getAdapter()).toBeNull();
   });
 
+  test('detach unregisters every adapter listener attach() registered (onAdapterEvent bookkeeping)', () => {
+    const engine = new HlsMediaEngine();
+    const ctx = createTestMediaEngineContext();
+    engine.attach(ctx);
+
+    // Grab the live adapter reference before detach() nulls it out, so we can still
+    // inspect its internal handler map afterwards.
+    const adapter = engine.getAdapter<HlsMockWithEmit>()!;
+    const handlers = (adapter as unknown as { handlers: Map<string, Set<unknown>> }).handlers;
+    const countRegistered = () => Array.from(handlers.values()).reduce((sum, set) => sum + set.size, 0);
+
+    // Sanity: attach() actually registered listeners via onAdapterEvent — both the
+    // generic per-event forwarder loop and the named lifecycle handlers (MANIFEST_PARSED,
+    // MEDIA_ATTACHED, LEVEL_LOADED, LEVEL_UPDATED, SUBTITLE_TRACKS_UPDATED, ERROR).
+    expect(countRegistered()).toBeGreaterThan(0);
+
+    engine.detach();
+
+    // unbindAdapterEvents() must have called adapter.off() for every listener onAdapterEvent
+    // pushed onto adapterListeners, leaving no dangling handlers on the (still-referenced) adapter.
+    expect(countRegistered()).toBe(0);
+  });
+
   // ── canPlay explicit MIME / URL branches ──────────────────────────────────
 
   test('canPlay – accepts application/x-mpegURL MIME type', () => {

--- a/packages/hls/src/hls.ts
+++ b/packages/hls/src/hls.ts
@@ -1,5 +1,5 @@
 import type { IEngine, MediaEngineContext, MediaSource } from '@openplayerjs/core';
-import { BaseMediaEngine, EVENT_OPTIONS } from '@openplayerjs/core';
+import { BaseMediaEngine } from '@openplayerjs/core';
 import type { ErrorData, HlsConfig, LevelLoadedData, LevelUpdatedData } from 'hls.js';
 import Hls from 'hls.js';
 
@@ -13,7 +13,6 @@ type HlsEventHandler = (...args: never[]) => void;
 type AdapterListener = {
   event: string;
   handler: HlsEventHandler;
-  options?: AddEventListenerOptions;
 };
 
 /** hls.js `.on`/`.off` narrowed to a string-keyed event API for the generic forwarder. */
@@ -87,14 +86,10 @@ export class HlsMediaEngine extends BaseMediaEngine implements IEngine {
     this.adapter.attachMedia(ctx.media);
 
     for (const e of Object.values(this.HlsClass.Events) as string[]) {
-      this.onAdapterEvent(
-        e,
-        (...args: unknown[]) => {
-          const data = args.length > 1 ? args[1] : args[0];
-          ctx.events.emit(e, data);
-        },
-        EVENT_OPTIONS
-      );
+      this.onAdapterEvent(e, (...args: unknown[]) => {
+        const data = args.length > 1 ? args[1] : args[0];
+        ctx.events.emit(e, data);
+      });
     }
 
     const onPlay = () => {
@@ -118,94 +113,74 @@ export class HlsMediaEngine extends BaseMediaEngine implements IEngine {
       })
     );
 
-    this.onAdapterEvent(this.HlsClass.Events.MANIFEST_PARSED, () => ctx.events.emit('loadedmetadata'), EVENT_OPTIONS);
-    this.onAdapterEvent(
-      this.HlsClass.Events.MEDIA_ATTACHED,
-      () => {
-        if (ctx.media.autoplay && this.canHandlePlayback(ctx)) {
-          ctx.surface.muted = true;
-          void ctx.surface.play();
-        }
-      },
-      EVENT_OPTIONS
-    );
+    this.onAdapterEvent(this.HlsClass.Events.MANIFEST_PARSED, () => ctx.events.emit('loadedmetadata'));
+    this.onAdapterEvent(this.HlsClass.Events.MEDIA_ATTACHED, () => {
+      if (ctx.media.autoplay && this.canHandlePlayback(ctx)) {
+        ctx.surface.muted = true;
+        void ctx.surface.play();
+      }
+    });
     // LEVEL_LOADED fires once per level load — keep `core.isLive` in sync.
     // Duration itself reaches the player via the native `durationchange` event
     // (bridged by bindMediaEvents) which updates `core.duration`.
-    this.onAdapterEvent(
-      this.HlsClass.Events.LEVEL_LOADED,
-      (_: unknown, { details }: LevelLoadedData) => {
-        ctx.core.isLive = details.live;
-      },
-      EVENT_OPTIONS
-    );
+    this.onAdapterEvent(this.HlsClass.Events.LEVEL_LOADED, (_: unknown, { details }: LevelLoadedData) => {
+      ctx.core.isLive = details.live;
+    });
     // LEVEL_UPDATED fires on every playlist refresh (frequent on live streams).
     // Keep its work minimal: only sync isLive and process EXT-X-DATERANGE SCTE-35
     // cues for the hybrid ad strategy.
-    this.onAdapterEvent(
-      this.HlsClass.Events.LEVEL_UPDATED,
-      (_, { details }: LevelUpdatedData) => {
-        ctx.core.isLive = details.live;
-        if (this.onCue && details?.dateRanges) {
-          for (const [id, range] of Object.entries(details.dateRanges)) {
-            if (!range || this.seenCueIds.has(id)) continue;
-            const attr = range.attr;
-            const scte35Out = attr?.['SCTE35-OUT'];
-            if (!scte35Out) continue;
-            this.seenCueIds.add(id);
-            this.onCue({
-              id,
-              scte35Out,
-              plannedDuration: typeof range.plannedDuration === 'number' ? range.plannedDuration : undefined,
-              startDate: range.startDate instanceof Date ? range.startDate : undefined,
-            });
-          }
+    this.onAdapterEvent(this.HlsClass.Events.LEVEL_UPDATED, (_, { details }: LevelUpdatedData) => {
+      ctx.core.isLive = details.live;
+      if (this.onCue && details?.dateRanges) {
+        for (const [id, range] of Object.entries(details.dateRanges)) {
+          if (!range || this.seenCueIds.has(id)) continue;
+          const attr = range.attr;
+          const scte35Out = attr?.['SCTE35-OUT'];
+          if (!scte35Out) continue;
+          this.seenCueIds.add(id);
+          this.onCue({
+            id,
+            scte35Out,
+            plannedDuration: typeof range.plannedDuration === 'number' ? range.plannedDuration : undefined,
+            startDate: range.startDate instanceof Date ? range.startDate : undefined,
+          });
         }
-      },
-      EVENT_OPTIONS
-    );
-    this.onAdapterEvent(
-      this.HlsClass.Events.SUBTITLE_TRACKS_UPDATED,
-      () => ctx.events.emit('texttrack:listchange'),
-      EVENT_OPTIONS
-    );
-    this.onAdapterEvent(
-      this.HlsClass.Events.ERROR,
-      (_: unknown, data: ErrorData) => {
-        if (data.fatal) {
-          switch (data.type) {
-            case this.HlsClass.ErrorTypes.MEDIA_ERROR: {
-              const now = Date.now();
-              if (!this.attemptedErrorRecovery || now - this.attemptedErrorRecovery > ERROR_RECOVERY_THROTTLE_MS) {
-                this.attemptedErrorRecovery = now;
+      }
+    });
+    this.onAdapterEvent(this.HlsClass.Events.SUBTITLE_TRACKS_UPDATED, () => ctx.events.emit('texttrack:listchange'));
+    this.onAdapterEvent(this.HlsClass.Events.ERROR, (_: unknown, data: ErrorData) => {
+      if (data.fatal) {
+        switch (data.type) {
+          case this.HlsClass.ErrorTypes.MEDIA_ERROR: {
+            const now = Date.now();
+            if (!this.attemptedErrorRecovery || now - this.attemptedErrorRecovery > ERROR_RECOVERY_THROTTLE_MS) {
+              this.attemptedErrorRecovery = now;
+              this.adapter?.recoverMediaError();
+            } else {
+              if (
+                !this.recoverSwapAudioCodecTimestamp ||
+                now - this.recoverSwapAudioCodecTimestamp > ERROR_RECOVERY_THROTTLE_MS
+              ) {
+                this.recoverSwapAudioCodecTimestamp = now;
+                this.adapter?.swapAudioCodec();
                 this.adapter?.recoverMediaError();
-              } else {
-                if (
-                  !this.recoverSwapAudioCodecTimestamp ||
-                  now - this.recoverSwapAudioCodecTimestamp > ERROR_RECOVERY_THROTTLE_MS
-                ) {
-                  this.recoverSwapAudioCodecTimestamp = now;
-                  this.adapter?.swapAudioCodec();
-                  this.adapter?.recoverMediaError();
-                }
               }
-              break;
             }
-            case this.HlsClass.ErrorTypes.NETWORK_ERROR:
-              // All retries and media options have been exhausted.
-              // Immediately trying to restart loading could cause loop loading.
-              // Consider modifying loading policies to best fit your asset and network
-              // conditions (manifestLoadPolicy, playlistLoadPolicy, fragLoadPolicy).
-              break;
-            default:
-              this.adapter?.destroy();
-              this.adapter = null;
-              break;
+            break;
           }
+          case this.HlsClass.ErrorTypes.NETWORK_ERROR:
+            // All retries and media options have been exhausted.
+            // Immediately trying to restart loading could cause loop loading.
+            // Consider modifying loading policies to best fit your asset and network
+            // conditions (manifestLoadPolicy, playlistLoadPolicy, fragLoadPolicy).
+            break;
+          default:
+            this.adapter?.destroy();
+            this.adapter = null;
+            break;
         }
-      },
-      EVENT_OPTIONS
-    );
+      }
+    });
   }
 
   private ensurePlaybackOwnership(ctx: MediaEngineContext): boolean {
@@ -260,13 +235,13 @@ export class HlsMediaEngine extends BaseMediaEngine implements IEngine {
     this.seenCueIds.clear();
   }
 
-  private onAdapterEvent(event: string, handler: HlsEventHandler, options?: AddEventListenerOptions) {
+  private onAdapterEvent(event: string, handler: HlsEventHandler) {
     if (!this.adapter) return;
     // hls.js types `.on`/`.off` per-event via its `Events` enum; the generic forwarder
     // works structurally, so narrow the adapter to a string-keyed event API.
     const adapter = this.adapter as unknown as HlsStringEventApi;
     adapter.on(event, handler);
-    this.adapterListeners.push({ event, handler, options });
+    this.adapterListeners.push({ event, handler });
   }
 
   private unbindAdapterEvents() {


### PR DESCRIPTION
## What
`HlsMediaEngine.onAdapterEvent(event, handler, options?)` accepted an `AddEventListenerOptions` and stored it on each `AdapterListener` entry, but it was never read: `adapter.on(event, handler)` is called with only 2 args, and `unbindAdapterEvents()`'s `adapter.off(l.event, l.handler)` never touches `l.options`. hls.js's `.on`/`.off` are EventEmitter3-based (`event, listener[, context, once]`), not DOM `EventTarget` — there's no `AddEventListenerOptions` concept for hls.js events at all, so the `EVENT_OPTIONS` constant passed at all 7 call sites in `attach()` was captured and immediately discarded every time.

Removed the `options` field from `AdapterListener`, the `options` param from `onAdapterEvent`, the `EVENT_OPTIONS` argument from all 7 call sites, and the now-unused `EVENT_OPTIONS` import from `@openplayerjs/core`.

## Why it's safe
- Purely internal: `AdapterListener`/`onAdapterEvent`/`unbindAdapterEvents` are all `private` to `HlsMediaEngine`, not part of the public API.
- Doesn't touch the hls.js config object shape, `MANIFEST_PARSED`→`loadedmetadata`, `LEVEL_LOADED`/`LEVEL_UPDATED` isLive sync, or the SCTE-35 dateRanges handling (all load-bearing per `hls/CLAUDE.md`).
- `dist/types/` verified byte-identical to `master`'s baseline build.

## Tests
New regression test captures the mock adapter's live listener-handler map before/after `attach()`+`detach()`, asserting `attach()` actually registers listeners (generic per-event forwarder loop + 6 named lifecycle handlers) and `detach()` removes every one of them via `unbindAdapterEvents()`. This pins down the `onAdapterEvent`/`unbindAdapterEvents` register-unregister bookkeeping the refactor touches; it passes identically pre- and post-fix (expected, since `options` never affected observable behavior), but would catch a regression in the push/off pairing introduced by the refactor.

## Verification
`type-check`, `lint`, `build`, full test suite (1162 tests, 79 suites, `hls.ts` 98.42/93.75/100/100) all green; overall coverage 96.17/85.92/92.66/98.38 (≥85% threshold); no new `as any`/`@ts-ignore`/`@ts-expect-error`/`eslint-disable`; touched files limited to `packages/hls/src/hls.ts` and its `__tests__` counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
