### PR TITLE
perf(core): make Core.emit's plugin notification a single pass

### DIFF
--- a/packages/core/__tests__/core.player.test.ts
+++ b/packages/core/__tests__/core.player.test.ts
@@ -31,6 +31,29 @@ describe('Player core', () => {
     expect(seen).toEqual([['media:rate', 1.25]]);
   });
 
+  test('emit skips media-engine plugins and notifies every other plugin, in registration order', () => {
+    const p = makeCore();
+    const seen: string[] = [];
+    const makePlugin = (name: string, mediaEngine: boolean): PlayerPlugin => ({
+      name,
+      version: '1',
+      capabilities: mediaEngine ? ['media-engine'] : [],
+      onEvent(evt) {
+        seen.push(`${name}:${evt}`);
+      },
+    });
+
+    // Interleave a media-engine plugin between two ordinary ones to prove the
+    // exclusion filter and the ordering both survive a single-pass rewrite.
+    p.registerPlugin(makePlugin('a', false));
+    p.registerPlugin(makePlugin('engine', true));
+    p.registerPlugin(makePlugin('b', false));
+
+    p.emit('media:rate', 1);
+
+    expect(seen).toEqual(['a:media:rate', 'b:media:rate']);
+  });
+
   test('play emits cmd:play immediately (user-gesture context) and does not double-fire; pause emits cmd:pause', async () => {
     const p = makeCore();
     const calls: string[] = [];

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -102,12 +102,13 @@ export class Core {
 
   emit(event: PlayerEvent | string, payload?: unknown) {
     this.events.emit(event, payload);
-    this.plugins
-      .all()
-      .filter((p: PlayerPlugin) => !p.capabilities?.includes('media-engine'))
-      .forEach((p: PlayerPlugin) => {
-        p.onEvent?.(event as PlayerEvent, payload);
-      });
+    // Single pass instead of filter().forEach(): this runs on every cmd:* emission
+    // (volume/mute/rate/seek drags fire it continuously), so avoid allocating a
+    // throwaway filtered array each call.
+    for (const p of this.plugins.all()) {
+      if (p.capabilities?.includes('media-engine')) continue;
+      p.onEvent?.(event as PlayerEvent, payload);
+    }
   }
 
   registerPlugin(plugin: PlayerPlugin) {


### PR DESCRIPTION
## What
`Core.emit()` chained `.filter(...).forEach(...)` over `this.plugins.all()` on every call, allocating a throwaway filtered array each time purely to immediately consume it once and discard it. `emit()` is not a cold path: it's driven by `cmd:setVolume`/`cmd:setMuted`/`cmd:setRate`/`cmd:seek` from the volume/muted/playbackRate/currentTime setters, which `controls/volume.ts` and `controls/progress.ts` write on every pointermove tick while a user drags a slider, plus `cmd:play`/`cmd:pause` and the lease-resync path. `plugins.all()` returns the registry's live internal array (no defensive copy), so the filter re-walked and re-allocated on every single emit.

Replaced with a single `for...of` + `continue` that visits the exact same plugins, in the exact same order, calling `onEvent` with the exact same arguments.

## Why it's safe
- `Array.prototype.filter`/`forEach` already preserve iteration order, so this is a pure allocation removal with no behavioral change. `Core.emit`'s public signature (`event, payload?`) is untouched.
- `dist/types/` verified byte-identical to `master`'s baseline build — important here since `core`'s public surface is what `player`/`ads`/`hls` all depend on.

## Tests
New regression test interleaves a `media-engine`-capability plugin between two ordinary plugins and asserts: the media-engine plugin's `onEvent` is never called, and the other two are called in registration order. This pins down both halves of the rewrite (the exclusion filter and the iteration order) that a single-pass loop could otherwise get wrong (e.g. an early `break` instead of `continue` would silently skip later plugins).

## Verification
`type-check`, `lint`, `build`, full test suite (1162 tests, 79 suites; core package 166 tests, 14 suites) all green; overall coverage 96.17/85.92/92.65/98.38 (≥85% threshold); no new `as any`/`@ts-ignore`/`@ts-expect-error`/`eslint-disable`; touched files limited to `packages/core/src/core/index.ts` and its `__tests__` counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
