### PR TITLE
perf(ads): cache derived break id/input across repeated schedule lookups

### DIFF
--- a/packages/ads/__tests__/schedule.branches.test.ts
+++ b/packages/ads/__tests__/schedule.branches.test.ts
@@ -379,6 +379,59 @@ describe('AdScheduler break-lookup methods avoid redundant getVastInputFromBreak
     expect(due).toHaveLength(2);
     expect(spy).toHaveBeenCalledTimes(2);
   });
+
+  it('getDueMidrollBreaks does not re-derive input/id for the same break objects across repeated calls', () => {
+    // Simulates the real hot path: bindBreakScheduler() calls getDueMidrollBreaks on every
+    // native `timeupdate` while resolvedBreaks stays the same array of break objects.
+    const sched = makeScheduler([]);
+    sched.resolvedBreaks = [
+      { at: 10, source: { type: 'VAST', src: 'https://example.com/m1.xml' } },
+      { at: 30, source: { type: 'VAST', src: 'https://example.com/m2.xml' } },
+    ];
+    const spy = jest.spyOn(sched, 'getVastInputFromBreak');
+
+    const first = sched.getDueMidrollBreaks(5);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // Repeated ticks against the same (unchanged) break objects must not re-derive.
+    const second = sched.getDueMidrollBreaks(15);
+    const third = sched.getDueMidrollBreaks(35);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    expect(first).toEqual([]);
+    expect(second.map((b) => b.at)).toEqual([10]);
+    expect(third.map((b) => b.at)).toEqual([10, 30]);
+  });
+
+  it('getPrerollBreak and getBreakId share the cached id for the same break object', () => {
+    const breakCfg: AdsBreakConfig = {
+      at: 'preroll',
+      source: { type: 'VAST', src: 'https://example.com/preroll.xml' },
+    };
+    const sched = makeScheduler([], [breakCfg]);
+    const spy = jest.spyOn(sched, 'getVastInputFromBreak');
+
+    const pre = sched.getPrerollBreak();
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // getBreakId on the same object should hit the cache populated by getPrerollBreak.
+    const id = sched.getBreakId(pre!);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(id).toBe(sched.getBreakId(breakCfg));
+  });
+
+  it('a fresh break object (new identity) is never confused with a cached one', () => {
+    const sched = makeScheduler([]);
+    const a: AdsBreakConfig = { at: 10, source: { type: 'VAST', src: 'https://example.com/a.xml' } };
+    const b: AdsBreakConfig = { at: 10, source: { type: 'VAST', src: 'https://example.com/b.xml' } };
+    sched.resolvedBreaks = [a];
+
+    const idA = sched.getBreakId(a);
+    sched.resolvedBreaks = [b];
+    const idB = sched.getBreakId(b);
+
+    expect(idA).not.toBe(idB);
+  });
 });
 
 describe('AdScheduler.inferSourceTypeForUrl', () => {

--- a/packages/ads/src/schedule.ts
+++ b/packages/ads/src/schedule.ts
@@ -108,6 +108,13 @@ export class AdScheduler {
   vmapLoadPromise: Promise<void> | null = null;
   pendingVmapSrc?: string;
 
+  // resolvedBreaks/cfg.breaks entries are never mutated after creation (source/sources/id
+  // are fixed at construction), so the derived input/sourceType/id triple is safe to cache
+  // by object identity. getDueMidrollBreaks runs on every native `timeupdate` while content
+  // plays, so recomputing this per break on every tick is pure waste once a break has been
+  // seen; the WeakMap keeps this from leaking should a break object ever be dropped.
+  private breakMetaCache = new WeakMap<AdsBreakConfig, { input?: VastInput; sourceType?: AdsSourceType; id: string }>();
+
   constructor(
     private cfg: Pick<
       Required<
@@ -152,27 +159,33 @@ export class AdScheduler {
     return getVastInputFromBreakFn(b);
   }
 
+  private resolveBreakMeta(b: AdsBreakConfig): { input?: VastInput; sourceType?: AdsSourceType; id: string } {
+    const cached = this.breakMetaCache.get(b);
+    if (cached) return cached;
+    const { input, sourceType } = this.getVastInputFromBreak(b);
+    const meta = { input, sourceType, id: breakIdFromInput(b, input, sourceType) };
+    this.breakMetaCache.set(b, meta);
+    return meta;
+  }
+
   getBreakId(b: AdsBreakConfig): string {
     if (b.id) return b.id;
-    const { input, sourceType } = this.getVastInputFromBreak(b);
-    return breakIdFromInput(b, input, sourceType);
+    return this.resolveBreakMeta(b).id;
   }
 
   getPrerollBreak(): AdsBreakConfig | undefined {
     for (const b of this.resolvedBreaks) {
       if (b.at !== 'preroll') continue;
-      const { input, sourceType } = this.getVastInputFromBreak(b);
+      const { input, id } = this.resolveBreakMeta(b);
       if (!input) continue;
-      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       return b;
     }
 
     for (const b of this.cfg.breaks) {
       if (b.at !== 'preroll') continue;
-      const { input, sourceType } = this.getVastInputFromBreak(b);
+      const { input, id } = this.resolveBreakMeta(b);
       if (!input) continue;
-      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       return b;
     }
@@ -192,9 +205,8 @@ export class AdScheduler {
   getPostrollBreak(): AdsBreakConfig | undefined {
     for (const b of this.resolvedBreaks) {
       if (b.at !== 'postroll') continue;
-      const { input, sourceType } = this.getVastInputFromBreak(b);
+      const { input, id } = this.resolveBreakMeta(b);
       if (!input) continue;
-      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       return b;
     }
@@ -217,9 +229,8 @@ export class AdScheduler {
     const due: AdsBreakConfig[] = [];
     for (const b of this.resolvedBreaks) {
       if (typeof b.at !== 'number') continue;
-      const { input, sourceType } = this.getVastInputFromBreak(b);
+      const { input, id } = this.resolveBreakMeta(b);
       if (!input) continue;
-      const id = breakIdFromInput(b, input, sourceType);
       if (b.once !== false && this.playedBreaks.has(id)) continue;
       if (currentTime + (this.cfg.breakTolerance ?? 0.25) >= b.at) due.push(b);
     }


### PR DESCRIPTION
## What changed

`AdScheduler` (`packages/ads/src/schedule.ts`) re-derived the same `{input, sourceType, id}` triple for every ad break on every call, via `getVastInputFromBreak()` + `breakIdFromInput()`. `getDueMidrollBreaks()` is on a hot path — it runs on every native `timeupdate` event while content plays (wired up in `csai.ts`'s `bindBreakScheduler()`) — so this recomputation (string trims, `startsWith` checks, id-string building) happened many times a second for breaks whose derived data can never change once created.

Added a private `resolveBreakMeta()` that memoizes the triple in a `WeakMap<AdsBreakConfig, ...>` keyed by break-object identity, and routed `getBreakId()`, `getPrerollBreak()`, `getPostrollBreak()`, and `getDueMidrollBreaks()` through it. Break configs are never mutated after creation anywhere in the codebase, so caching by identity is safe; a WeakMap needs no explicit invalidation — stale/replaced break objects (e.g. after `rebuild()` creates fresh ones) simply miss the cache and recompute correctly, while GC reclaims old entries automatically.

## Why it's safe

- **Zero behavior change.** No existing test assertion was touched. Cache misses behave identically to before — the existing "`getVastInputFromBreak` called once per id-less break" perf tests in `schedule.branches.test.ts` still pass unmodified.
- **New regression tests added** (not edits) in `schedule.branches.test.ts`, pinning:
  - cross-call caching on `getDueMidrollBreaks` across repeated `timeupdate`-style calls
  - cache-sharing between `getBreakId()` and `getPrerollBreak()` for the same break object
  - correct non-collision for two distinct break objects (no false cache hits)
- **Public API surface verified, not assumed.** Built once on the `master` baseline and once with the change, diffed `packages/*/dist/types/`. Only `packages/ads/dist/types/schedule.d.ts` differs, and only by the two new **private** members (`breakMetaCache`, `resolveBreakMeta`) — inaccessible to any consumer, not part of the public contract.
- **Escape-hatch check clean** — no new `as any` / `@ts-ignore` / `@ts-expect-error` / `eslint-disable`.
- **Touches only** `packages/ads/src/schedule.ts` and its test file.

## Gate results

- `pnpm run type-check` — clean
- `pnpm run lint` — clean
- `pnpm run build` — clean
- `pnpm run test` — 1166/1166 passing; coverage unchanged (85.93% branches / 96.17% stmts / 92.65% funcs / 98.38% lines, all ≥85% threshold)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ch9rTE11a4AkjufchQts6z)_